### PR TITLE
#58 Refactor the GET reviews logic and change the review status to an enum

### DIFF
--- a/prisma/migrations/20250911064653_add_a_review_status/migration.sql
+++ b/prisma/migrations/20250911064653_add_a_review_status/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - The `status` column on the `review` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "ReviewStatus" AS ENUM ('PENDING', 'IN_PROGRESS', 'COMPLETED', 'DRAFT', 'SUBMITTED', 'APPROVED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "review" DROP COLUMN "status",
+ADD COLUMN     "status" "ReviewStatus";
+
+-- CreateIndex
+CREATE INDEX "review_status_idx" ON "review"("status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,6 +141,16 @@ model scorecardQuestion {
   @@index([sortOrder]) // Index for ordering questions
 }
 
+enum ReviewStatus {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+  DRAFT
+  SUBMITTED
+  APPROVED
+  REJECTED
+}
+
 model review {
   id                 String    @id @default(dbgenerated("gen_random_uuid()")) @db.VarChar(36)
   legacyId           String?
@@ -154,7 +164,7 @@ model review {
   initialScore       Float?
   typeId             String?
   metadata           Json?
-  status             String?
+  status             ReviewStatus?
   reviewDate         DateTime?
   createdAt          DateTime  @default(now())
   createdBy          String
@@ -170,6 +180,7 @@ model review {
   @@index([resourceId]) // Index for filtering by resource (reviewer)
   @@index([phaseId]) // Index for filtering by phase
   @@index([scorecardId]) // Index for joining with scorecard table
+  @@index([status]) // Index for filtering by review status
 }
 
 model reviewItem {

--- a/src/dto/review.dto.ts
+++ b/src/dto/review.dto.ts
@@ -24,6 +24,16 @@ export enum ReviewItemCommentType {
   SPECIFICATION_REVIEW_COMMENT = 'SPECIFICATION_REVIEW_COMMENT',
 }
 
+export enum ReviewStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  DRAFT = 'DRAFT',
+  SUBMITTED = 'SUBMITTED',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+}
+
 export class ReviewItemCommentBaseDto {
   @ApiProperty({
     description: 'Content of the comment',
@@ -222,11 +232,12 @@ export class ReviewBaseDto {
 
   @ApiProperty({
     description: 'Status for the review',
-    example: 'Review',
+    enum: ReviewStatus,
+    example: ReviewStatus.PENDING,
   })
   @IsString()
   @IsNotEmpty()
-  status: string;
+  status: ReviewStatus;
 
   @ApiProperty({
     description: 'Review date for the review',
@@ -316,12 +327,13 @@ export class ReviewPatchRequestDto {
 
   @ApiProperty({
     description: 'Status for the review',
-    example: 'Review',
+    enum: ReviewStatus,
+    example: ReviewStatus.PENDING,
   })
   @IsOptional()
   @IsString()
   @IsNotEmpty()
-  status?: string;
+  status?: ReviewStatus;
 
   @ApiProperty({
     description: 'Review date for the review',


### PR DESCRIPTION
The original implementation was completely incorrect.

1. The endpoint was filtering by scorecard.status (ScorecardStatus enum) instead of review.status (string field)
2. The original implementation had convoluted logic with separate queries for scorecard status and challengeId, causing duplication and inefficiency
3. The POST /v6/reviews works directly with review records, but GET was going through scorecards
4. It was incorrectly using challengeResult table to find submissions.

5. The original review status is a string, I created a ReviewStatus enum with the following values:
  - PENDING - Review waiting to be started
  - IN_PROGRESS - Review currently being worked on
  - COMPLETED - Review finished
  - DRAFT - Review saved as draft
  - SUBMITTED - Review submitted for approval
  - APPROVED - Review has been approved
  - REJECTED - Review has been rejected
  
