### PR TITLE
#70 Fix the 404 error for valid review item id

### DIFF
--- a/src/api/review-opportunity/reviewOpportunity.controller.ts
+++ b/src/api/review-opportunity/reviewOpportunity.controller.ts
@@ -206,7 +206,7 @@ export class ReviewOpportunityController {
   @ApiOperation({
     summary: 'Update review opportunity by id',
     description:
-      'Any user should be able to see opportunity. Including anonymous.',
+      'Roles: Admin | Copilot | Scopes: update:review_opportunity, all:review_opportunity',
   })
   @ApiBody({
     description: 'Review opportunity data',

--- a/src/api/review/review.controller.ts
+++ b/src/api/review/review.controller.ts
@@ -36,6 +36,7 @@ import {
   ReviewStatus,
   mapReviewRequestToDto,
   mapReviewItemRequestToDto,
+  mapReviewItemRequestForUpdate,
 } from 'src/dto/review.dto';
 import { PrismaService } from '../../shared/modules/global/prisma.service';
 import { LoggerService } from '../../shared/modules/global/logger.service';
@@ -304,7 +305,7 @@ export class ReviewController {
     try {
       const data = await this.prisma.reviewItem.update({
         where: { id: itemId },
-        data: mapReviewItemRequestToDto(body),
+        data: mapReviewItemRequestForUpdate(body),
         include: {
           reviewItemComments: true,
         },

--- a/src/dto/review.dto.ts
+++ b/src/dto/review.dto.ts
@@ -487,6 +487,29 @@ export function mapReviewItemRequestToDto(
   return payload;
 }
 
+export function mapReviewItemRequestForUpdate(
+  request: ReviewItemRequestDto,
+): Partial<MappedReviewItem> {
+  const userFields = {
+    updatedBy: '',
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { reviewId, reviewItemComments, ...rest } = request as {
+    reviewId?: string;
+    reviewItemComments?: any[];
+  } & ReviewItemRequestDto;
+
+  // For updates, we only include the core review item fields
+  // Comments should be handled separately via dedicated comment endpoints
+  const payload: Partial<MappedReviewItem> = {
+    ...rest,
+    ...userFields,
+  };
+
+  return payload;
+}
+
 export class ReviewProgressResponseDto {
   @ApiProperty({
     description: 'The ID of the challenge',


### PR DESCRIPTION
Root Cause:
  The mapReviewItemRequestToDto function was designed for creating new review items and included nested create operations for reviewItemComments. When used for updates, these nested create operations caused
  Prisma to attempt invalid operations, leading to the 404 error.

 Solution:
  1. Created a new mapping function mapReviewItemRequestForUpdate specifically for handling review item updates
  2. Updated the PATCH endpoint to use the new mapping function.