### PR TITLE
PM-2131 - allow other types of authentication tokens throughout the app

### DIFF
--- a/src/shared/guards/gitea-webhook-auth.guard.ts
+++ b/src/shared/guards/gitea-webhook-auth.guard.ts
@@ -45,7 +45,7 @@ export class GiteaWebhookAuthGuard implements CanActivate {
         throw new BadRequestException('Missing authorization header');
       }
 
-      if (authHeader !== `Bearer ${auth}`) {
+      if (authHeader !== `SecretKey ${auth}`) {
         this.logger.error('Invalid authorization header');
         throw new ForbiddenException('Invalid authorization');
       }

--- a/src/shared/request/tokenRequestValidator.middleware.ts
+++ b/src/shared/request/tokenRequestValidator.middleware.ts
@@ -22,7 +22,11 @@ export class TokenValidatorMiddleware implements NestMiddleware {
 
     const [type, idToken] = request.headers.authorization.split(' ') ?? [];
 
-    if (type !== 'Bearer' || !idToken) {
+    if (type !== 'Bearer') {
+      return next();
+    }
+    
+    if (!idToken) {
       throw new UnauthorizedException('Invalid or missing JWT!');
     }
 


### PR DESCRIPTION
For gitea, use a token of type "SecurityKey" instead of "Bearer" so we can differentiate it from the jwt tokens. 