### PR TITLE
PM-3851 make sure to convert decimal to number

### DIFF
--- a/src/api/ai-review-config/ai-review-config.service.ts
+++ b/src/api/ai-review-config/ai-review-config.service.ts
@@ -249,7 +249,17 @@ export class AiReviewConfigService {
         `AI review config for challenge ${challengeId} not found.`,
       );
     }
-    return config;
+    return {
+      ...config,
+      minPassingThreshold:
+        config.minPassingThreshold != null
+          ? Number(config.minPassingThreshold)
+          : config.minPassingThreshold,
+      workflows: config.workflows.map((w) => ({
+        ...w,
+        weightPercent: Number(w.weightPercent),
+      })),
+    };
   }
 
   async getById(id: string) {
@@ -261,7 +271,17 @@ export class AiReviewConfigService {
       this.logger.error(`AI review config with id ${id} not found.`);
       throw new NotFoundException(`AI review config with id ${id} not found.`);
     }
-    return config;
+    return {
+      ...config,
+      minPassingThreshold:
+        config.minPassingThreshold != null
+          ? Number(config.minPassingThreshold)
+          : config.minPassingThreshold,
+      workflows: config.workflows.map((w) => ({
+        ...w,
+        weightPercent: Number(w.weightPercent),
+      })),
+    };
   }
 
   async update(id: string, dto: UpdateAiReviewConfigDto) {
@@ -282,6 +302,8 @@ export class AiReviewConfigService {
       configData.autoFinalize = rest.autoFinalize;
     if (rest.formula !== undefined)
       configData.formula = rest.formula as Prisma.InputJsonValue;
+
+    if (rest.templateId !== undefined) configData.templateId = rest.templateId || null;
 
     if (workflows !== undefined && workflows.length > 0) {
       await this.validateWorkflowIdsExist(workflows.map((w) => w.workflowId));
@@ -349,10 +371,22 @@ export class AiReviewConfigService {
       where.mode = filters.mode as AiReviewMode;
     }
 
-    return this.prisma.aiReviewConfig.findMany({
+    const results = await this.prisma.aiReviewConfig.findMany({
       where,
       include: CONFIG_INCLUDE,
       orderBy: [{ challengeId: 'asc' }, { version: 'desc' }],
     });
+
+    return results.map((config) => ({
+      ...config,
+      minPassingThreshold:
+        config.minPassingThreshold != null
+          ? Number(config.minPassingThreshold)
+          : config.minPassingThreshold,
+      workflows: config.workflows.map((w) => ({
+        ...w,
+        weightPercent: Number(w.weightPercent),
+      })),
+    }));
   }
 }

--- a/src/api/ai-review-template/ai-review-template.service.ts
+++ b/src/api/ai-review-template/ai-review-template.service.ts
@@ -187,7 +187,17 @@ export class AiReviewTemplateService {
         `AI review template with id ${id} not found.`,
       );
     }
-    return template;
+    return {
+      ...template,
+      minPassingThreshold:
+        template.minPassingThreshold != null
+          ? Number(template.minPassingThreshold)
+          : template.minPassingThreshold,
+      workflows: template.workflows.map((w) => ({
+        ...w,
+        weightPercent: Number(w.weightPercent),
+      })),
+    };
   }
 
   async findAll(filters: { challengeTrack?: string; challengeType?: string }) {
@@ -199,10 +209,22 @@ export class AiReviewTemplateService {
       where.challengeType = filters.challengeType.trim();
     }
 
-    return this.prisma.aiReviewTemplateConfig.findMany({
+    const results = await this.prisma.aiReviewTemplateConfig.findMany({
       where,
       include: TEMPLATE_INCLUDE,
     });
+
+    return results.map((template) => ({
+      ...template,
+      minPassingThreshold:
+        template.minPassingThreshold != null
+          ? Number(template.minPassingThreshold)
+          : template.minPassingThreshold,
+      workflows: template.workflows.map((w) => ({
+        ...w,
+        weightPercent: Number(w.weightPercent),
+      })),
+    }));
   }
 
   async update(id: string, dto: UpdateAiReviewTemplateConfigDto) {

--- a/src/dto/aiReviewConfig.dto.ts
+++ b/src/dto/aiReviewConfig.dto.ts
@@ -112,7 +112,7 @@ export class CreateAiReviewConfigDto {
 
 export class UpdateAiReviewConfigDto extends OmitType(
   PartialType(CreateAiReviewConfigDto),
-  ['challengeId', 'templateId'],
+  ['challengeId'],
 ) {}
 
 export class ListAiReviewConfigQueryDto {


### PR DESCRIPTION
Two issues:
- convert decimal values to numbers when returning data. otherwise values like weights, thresholds, are converted to strings
- allow templateId to be passed in the PUT config call. This allows us to switch from template based config to manual config (so we need to send templateId = null)