### PR TITLE
fix(PM-3848): validate if ai run exists for the any of the submission when updating/deleting review config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ workflows:
                       branches:
                           only:
                               - develop
-                              - fix-lint
+                              - pm-3833_2
 
 
             - 'build-prod':

--- a/src/api/ai-review-config/ai-review-config.service.ts
+++ b/src/api/ai-review-config/ai-review-config.service.ts
@@ -203,9 +203,27 @@ export class AiReviewConfigService {
     }
   }
 
+  private async validateNoAiRunsExistForChallenge(
+    challengeId: string,
+  ): Promise<void> {
+    const count = await this.prisma.aiWorkflowRun.count({
+      where: {
+        submission: {
+          challengeId,
+        },
+      },
+    });
+    if (count > 0) {
+      throw new ConflictException(
+        `Cannot create, update, or delete AI review config: challenge ${challengeId} already has AI workflow runs.`,
+      );
+    }
+  }
+
   async create(dto: CreateAiReviewConfigDto, authUser: JwtUser) {
     await this.validateChallengeExists(dto.challengeId);
     await this.validateNoSubmissionsExistForChallenge(dto.challengeId);
+    await this.validateNoAiRunsExistForChallenge(dto.challengeId);
     await this.validateCopilotIsResourceForChallenge(dto.challengeId, authUser);
 
     let payload: {
@@ -369,6 +387,7 @@ export class AiReviewConfigService {
     await this.validateCopilotIsResourceForChallenge(challengeId, authUser);
     await this.validateChallengeNotCompleted(challengeId);
     await this.validateNoDecisionsForConfig(id);
+    await this.validateNoAiRunsExistForChallenge(challengeId);
 
     const { workflows, ...rest } = dto;
     const configData: Parameters<
@@ -427,6 +446,7 @@ export class AiReviewConfigService {
     );
     await this.validateChallengeNotCompleted(config.challengeId);
     await this.validateNoDecisionsForConfig(id);
+    await this.validateNoAiRunsExistForChallenge(config.challengeId);
 
     try {
       await this.prisma.aiReviewConfig.delete({


### PR DESCRIPTION
## What's in this PR?

- validate if ai run exists for the any of the submission when updating/deleting review config

Ticket link - https://topcoder.atlassian.net/browse/PM-3848

