### PR TITLE
fix(PM-3849): validation to block submitters to not see other submissions ai decisions when the challenge is not completed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ workflows:
                       branches:
                           only:
                               - develop
+                              - pm-3849_3
 
             - 'build-prod':
                   context: org-global

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -139,10 +139,10 @@ export class AiReviewDecisionService {
             await this.challengeApiService.getChallengeDetail(challengeId);
           if (
             challenge.status !== ChallengeStatus.COMPLETED &&
-            sub.memberId !== String(authUser.userId)
+            sub.memberId !== authUser.userId?.toString()
           ) {
             throw new ForbiddenException(
-              `You are not allowed to view this submission's AI review decisions. challengeId: ${challengeId}, memberId: ${sub.memberId}, userId: ${authUser.userId} typeof memberId: ${typeof sub.memberId} typeof userId: ${typeof authUser.userId}`,
+              `You are not allowed to view this submission's AI review decisions. challengeId: ${challengeId}, memberId: ${sub.memberId}, userId: ${authUser.userId} typeof memberId: ${typeof sub.memberId} typeof userId: ${typeof authUser.userId?.toString()}`,
             );
           }
         }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -142,7 +142,7 @@ export class AiReviewDecisionService {
             sub.memberId !== authUser.userId?.toString()
           ) {
             throw new ForbiddenException(
-              `You are not allowed to view this submission's AI review decisions. challengeId: ${challengeId}, memberId: ${sub.memberId}, userId: ${authUser.userId} typeof memberId: ${typeof sub.memberId} typeof userId: ${typeof authUser.userId?.toString()}`,
+              `You are not allowed to view this submission's AI review decisions.`,
             );
           }
         }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -139,7 +139,7 @@ export class AiReviewDecisionService {
             await this.challengeApiService.getChallengeDetail(challengeId);
           if (
             challenge.status !== ChallengeStatus.COMPLETED &&
-            sub.memberId !== authUser.userId
+            sub.memberId !== String(authUser.userId)
           ) {
             throw new ForbiddenException(
               `You are not allowed to view this submission's AI review decisions. challengeId: ${challengeId}, memberId: ${sub.memberId}, userId: ${authUser.userId} typeof memberId: ${typeof sub.memberId} typeof userId: ${typeof authUser.userId}`,

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -142,7 +142,7 @@ export class AiReviewDecisionService {
             sub.memberId !== authUser.userId
           ) {
             throw new ForbiddenException(
-              "You are not allowed to view this submission's AI review decisions.",
+              `You are not allowed to view this submission's AI review decisions. challengeId: ${challengeId}, memberId: ${sub.memberId}, userId: ${authUser.userId} typeof memberId: ${typeof sub.memberId} typeof userId: ${typeof authUser.userId}`,
             );
           }
         }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -135,9 +135,15 @@ export class AiReviewDecisionService {
         challengeId = sub.challengeId ?? null;
 
         if (challengeId) {
-          const challenge = await this.challengeApiService.getChallengeDetail(challengeId);
-          if (challenge.status !== ChallengeStatus.COMPLETED && sub.memberId !== authUser.userId) {
-            throw new ForbiddenException('You are not allowed to view this submission\'s AI review decisions.');
+          const challenge =
+            await this.challengeApiService.getChallengeDetail(challengeId);
+          if (
+            challenge.status !== ChallengeStatus.COMPLETED &&
+            sub.memberId !== authUser.userId
+          ) {
+            throw new ForbiddenException(
+              "You are not allowed to view this submission's AI review decisions.",
+            );
           }
         }
       }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -14,6 +14,8 @@ import {
   AiReviewDecisionStatus,
 } from '../../dto/aiReviewDecision.dto';
 import { Prisma } from '@prisma/client';
+import { ChallengeApiService } from 'src/shared/modules/global/challenge.service';
+import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
 
 const DECISION_INCLUDE = {
   config: {
@@ -31,6 +33,7 @@ export class AiReviewDecisionService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly resourcePrisma: ResourcePrismaService,
+    private readonly challengeApiService: ChallengeApiService,
   ) {
     this.logger = LoggerService.forRoot('AiReviewDecisionService');
   }
@@ -122,7 +125,7 @@ export class AiReviewDecisionService {
       } else if (query.submissionId) {
         const sub = await this.prisma.submission.findUnique({
           where: { id: query.submissionId },
-          select: { challengeId: true },
+          select: { challengeId: true, memberId: true },
         });
         if (!sub) {
           throw new NotFoundException(
@@ -130,6 +133,13 @@ export class AiReviewDecisionService {
           );
         }
         challengeId = sub.challengeId ?? null;
+
+        if (challengeId) {
+          const challenge = await this.challengeApiService.getChallengeDetail(challengeId);
+          if (challenge.status !== ChallengeStatus.COMPLETED && sub.memberId !== authUser.userId) {
+            throw new ForbiddenException('You are not allowed to view this submission\'s AI review decisions.');
+          }
+        }
       }
       if (!challengeId) {
         throw new ForbiddenException(


### PR DESCRIPTION
## What's in this PR?

- validation to block submitters to not see other submissions ai decisions when the challenge is not completed

Ticket link - https://topcoder.atlassian.net/browse/PM-3849

