### PR TITLE
fix(PM-3849): Added challenge level access control on decision by id endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ workflows:
                           only:
                               - develop
                               - PM-3926_ai-screening-phase
-                              - pm-3848_fix
+                              - pm-3849_by_id
 
             - 'build-prod':
                   context: org-global

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -62,7 +62,7 @@ export class AiReviewDecisionService {
     });
     if (!resource) {
       throw new ForbiddenException(
-        'You must be assigned to this challenge to view its AI review decisions.',
+        `You must be assigned to this challenge to view its AI review decisions. Challenge ID: ${challengeId} User ID: ${memberId} Resource ID: ${JSON.stringify(resource)}`,
       );
     }
   }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -82,6 +82,7 @@ export class AiReviewDecisionService {
       'checkpoint reviewer',
       'checkpoint screener',
       'iterative reviewer',
+      'reviewer',
       'screener',
     ],
   ): Promise<boolean> {
@@ -272,6 +273,16 @@ export class AiReviewDecisionService {
     return decisions.map((d) => this.mapToResponse(d));
   }
 
+  private async validateChallengeAccess(challengeId: string, userId: string, submissionMemberId: string): Promise<void> {
+    const hasExtendedViewAccess =
+        await this.hasExtendedViewAccessForChallenge(challengeId, userId);
+      const challenge =
+        await this.challengeApiService.getChallengeDetail(challengeId);
+      if (challenge.status !== ChallengeStatus.COMPLETED && !hasExtendedViewAccess && submissionMemberId !== userId) {
+        throw new ForbiddenException('You are not allowed to view this submission\'s AI review decisions.');
+      }
+  }
+
   async getById(
     id: string,
     authUser: JwtUser,
@@ -291,6 +302,11 @@ export class AiReviewDecisionService {
       decision.config?.challengeId ?? decision.submission?.challengeId ?? null;
     if (challengeId) {
       await this.validateCallerHasResourceForChallenge(challengeId, authUser);
+    }
+
+    const isAllowed = authUser.isMachine || isAdmin(authUser);
+    if (!isAllowed && authUser.userId && decision.submission?.memberId) {
+      await this.validateChallengeAccess(challengeId, authUser.userId, decision.submission.memberId);
     }
 
     return this.mapToResponse(decision);

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -273,14 +273,26 @@ export class AiReviewDecisionService {
     return decisions.map((d) => this.mapToResponse(d));
   }
 
-  private async validateChallengeAccess(challengeId: string, userId: string, submissionMemberId: string): Promise<void> {
-    const hasExtendedViewAccess =
-        await this.hasExtendedViewAccessForChallenge(challengeId, userId);
-      const challenge =
-        await this.challengeApiService.getChallengeDetail(challengeId);
-      if (challenge.status !== ChallengeStatus.COMPLETED && !hasExtendedViewAccess && submissionMemberId !== userId) {
-        throw new ForbiddenException('You are not allowed to view this submission\'s AI review decisions.');
-      }
+  private async validateChallengeAccess(
+    challengeId: string,
+    userId: string,
+    submissionMemberId: string,
+  ): Promise<void> {
+    const hasExtendedViewAccess = await this.hasExtendedViewAccessForChallenge(
+      challengeId,
+      userId,
+    );
+    const challenge =
+      await this.challengeApiService.getChallengeDetail(challengeId);
+    if (
+      challenge.status !== ChallengeStatus.COMPLETED &&
+      !hasExtendedViewAccess &&
+      submissionMemberId !== userId
+    ) {
+      throw new ForbiddenException(
+        "You are not allowed to view this submission's AI review decisions.",
+      );
+    }
   }
 
   async getById(
@@ -306,7 +318,11 @@ export class AiReviewDecisionService {
 
     const isAllowed = authUser.isMachine || isAdmin(authUser);
     if (!isAllowed && authUser.userId && decision.submission?.memberId) {
-      await this.validateChallengeAccess(challengeId, authUser.userId, decision.submission.memberId);
+      await this.validateChallengeAccess(
+        challengeId,
+        authUser.userId,
+        decision.submission.memberId,
+      );
     }
 
     return this.mapToResponse(decision);

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -62,7 +62,7 @@ export class AiReviewDecisionService {
     });
     if (!resource) {
       throw new ForbiddenException(
-        `You must be assigned to this challenge to view its AI review decisions. Challenge ID: ${challengeId} User ID: ${memberId} Resource ID: ${JSON.stringify(resource)}`,
+        `You must be assigned to this challenge to view its AI review decisions.`,
       );
     }
   }
@@ -320,7 +320,7 @@ export class AiReviewDecisionService {
     if (!isAllowed && authUser.userId && decision.submission?.memberId) {
       await this.validateChallengeAccess(
         challengeId,
-        authUser.userId,
+        authUser.userId.toString().trim(),
         decision.submission.memberId,
       );
     }


### PR DESCRIPTION
## What's in this PR?

- Added challenge level access control on decision by id endpoint

Ticket link - https://topcoder.atlassian.net/browse/PM-3849

Note: will merge this PR without a review as this logic is already implemented in list endpoint just copied to details endpoint.
