### PR TITLE
PM-4394 prevent double approval for ai decisisons escalations

### DIFF
--- a/src/api/ai-review-escalation/ai-review-escalation.controller.ts
+++ b/src/api/ai-review-escalation/ai-review-escalation.controller.ts
@@ -105,7 +105,7 @@ export class AiReviewEscalationController {
   @ApiOperation({
     summary: 'Create an AI review escalation',
     description:
-      'Roles: Admin, Copilot, Reviewer, Screener, Checkpoint Screener. Reviewer: creates with PENDING_APPROVAL (escalationNotes required) when challenge is in Review or Iterative Review phase. Screener/Checkpoint Screener: same PENDING_APPROVAL flow when challenge is in Screening or Checkpoint Screening phase. Admin/Copilot: direct unlock with APPROVED (approverNotes required). Override not allowed for passing decisions.',
+      'Roles: Admin, Copilot, Reviewer, Screener, Checkpoint Screener. Reviewer: creates with PENDING_APPROVAL (escalationNotes required) when challenge is in Review or Iterative Review phase. Screener/Checkpoint Screener: same PENDING_APPROVAL flow when challenge is in Screening or Checkpoint Screening phase. Admin/Copilot: direct unlock with APPROVED (approverNotes required). Override not allowed for passing decisions. Once an escalation is APPROVED for the decision, no further escalation or unlock actions are allowed.',
   })
   @ApiParam({
     name: 'id',
@@ -124,7 +124,7 @@ export class AiReviewEscalationController {
   @ApiResponse({
     status: 400,
     description:
-      'Bad Request. Missing required notes for role, or override not allowed for passing decision.',
+      'Bad Request. Missing required notes for role, override not allowed for passing decision, or an approved escalation already exists for this decision.',
   })
   @ApiResponse({
     status: 403,
@@ -149,7 +149,7 @@ export class AiReviewEscalationController {
   @ApiOperation({
     summary: 'Update an AI review escalation',
     description:
-      'Roles: Admin, Copilot. React to a PENDING_APPROVAL escalation: set approverNotes and status to APPROVED or REJECTED. If APPROVED, the decision is set to HUMAN_OVERRIDE and submissionLocked to false.',
+      'Roles: Admin, Copilot. React to a PENDING_APPROVAL escalation: set approverNotes and status to APPROVED or REJECTED. If APPROVED, the decision is set to HUMAN_OVERRIDE and submissionLocked to false. Once an escalation is APPROVED for the decision, no further escalation or unlock actions are allowed.',
   })
   @ApiParam({
     name: 'id',
@@ -173,7 +173,7 @@ export class AiReviewEscalationController {
   @ApiResponse({
     status: 400,
     description:
-      'Bad Request. Only PENDING_APPROVAL escalations can be updated.',
+      'Bad Request. Only PENDING_APPROVAL escalations can be updated, and updates are blocked if an approved escalation already exists for this decision.',
   })
   @ApiResponse({
     status: 404,

--- a/src/api/ai-review-escalation/ai-review-escalation.service.ts
+++ b/src/api/ai-review-escalation/ai-review-escalation.service.ts
@@ -1115,8 +1115,6 @@ They are requesting a manual override or secondary look at the AI Review results
       );
     }
 
-    await this.ensureNoApprovedEscalationExists(aiReviewDecisionId);
-
     await this.validatePhaseOpen(challengeId);
 
     if (

--- a/src/api/ai-review-escalation/ai-review-escalation.service.ts
+++ b/src/api/ai-review-escalation/ai-review-escalation.service.ts
@@ -762,6 +762,25 @@ They are requesting a manual override or secondary look at the AI Review results
     });
   }
 
+  private async ensureNoApprovedEscalationExists(
+    aiReviewDecisionId: string,
+  ): Promise<void> {
+    const approvedEscalation =
+      await this.prisma.aiReviewDecisionEscalation.findFirst({
+        where: {
+          aiReviewDecisionId,
+          status: PrismaAiReviewDecisionEscalationStatus.APPROVED,
+        },
+        select: { id: true },
+      });
+
+    if (approvedEscalation) {
+      throw new BadRequestException(
+        'This AI review decision already has an approved escalation. No further escalation or unlock actions are allowed.',
+      );
+    }
+  }
+
   private async createPendingEscalationForRole(
     aiReviewDecisionId: string,
     dto: CreateAiReviewEscalationDto,
@@ -905,6 +924,8 @@ They are requesting a manual override or secondary look at the AI Review results
         'Override is not allowed for a passing AI review decision.',
       );
     }
+
+    await this.ensureNoApprovedEscalationExists(aiReviewDecisionId);
 
     const userId = authUser.userId?.toString()?.trim() ?? null;
     if (!userId) {
@@ -1093,6 +1114,9 @@ They are requesting a manual override or secondary look at the AI Review results
         'Only Admin or a Copilot assigned to this challenge can update an escalation.',
       );
     }
+
+    await this.ensureNoApprovedEscalationExists(aiReviewDecisionId);
+
     await this.validatePhaseOpen(challengeId);
 
     if (


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-4394 - Shouldn't allow to unlock/escalate already escalated submissions
