### PR TITLE
F2f ai screening

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ workflows:
                               - pm-4172_2
                               - PM-4347_allow-creators-to-edit-ai-configs
                               - PM-4507
+                              - f2f-ai-screening
 
             - 'build-prod':
                   context: org-global

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -680,6 +680,6 @@ export class WorkflowQueueHandler implements OnModuleInit {
 
   private isFirst2FinishChallenge(typeName?: string): boolean {
     const normalized = (typeName ?? '').trim().toLowerCase();
-    return normalized === 'first2finish';
+    return normalized === 'first2finish' || normalized === 'first 2 finish';
   }
 }

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -540,8 +540,9 @@ export class WorkflowQueueHandler implements OnModuleInit {
   }
 
   /**
-   * Publish an event when all AI workflow runs for a challenge have completed.
-   * This is similar to publishReviewCompletedEvent but for the entire AI screening phase.
+   * Publish an event when AI workflow runs for a submission have completed.
+   * For F2F challenges, publishes immediately per-submission.
+   * For non-F2F challenges, waits for all AI workflows to complete.
    */
   async publishAiWorkflowPhaseCompletedEvent(
     challengeId: string,
@@ -597,17 +598,23 @@ export class WorkflowQueueHandler implements OnModuleInit {
         return;
       }
 
-      // Check if all AI workflows are complete
-      const allComplete = await this.areAllAiWorkflowsComplete(
-        challengeId,
-        aiWorkflowIds,
-      );
+      // For F2F challenges, publish immediately per-submission without waiting for all workflows.
+      // The autopilot will close the AI Screening phase and process submissions one at a time.
+      const isF2F = this.isFirst2FinishChallenge(challenge.type);
 
-      if (!allComplete) {
-        this.logger.debug(
-          `[publishAiWorkflowPhaseCompletedEvent] Not all AI workflows complete for challenge ${challengeId}`,
+      if (!isF2F) {
+        // For non-F2F challenges, wait for all AI workflows to complete
+        const allComplete = await this.areAllAiWorkflowsComplete(
+          challengeId,
+          aiWorkflowIds,
         );
-        return;
+
+        if (!allComplete) {
+          this.logger.debug(
+            `[publishAiWorkflowPhaseCompletedEvent] Not all AI workflows complete for challenge ${challengeId}`,
+          );
+          return;
+        }
       }
 
       // Get the most recent completed workflow run for this submission to use as representative data
@@ -652,7 +659,7 @@ export class WorkflowQueueHandler implements OnModuleInit {
         payload,
       );
       this.logger.log(
-        `[publishAiWorkflowPhaseCompletedEvent] Published AI workflow phase completion for challenge ${challengeId}, all AI workflows completed`,
+        `[publishAiWorkflowPhaseCompletedEvent] Published AI workflow completion for challenge ${challengeId}, submission ${submissionId}${isF2F ? ' (F2F)' : ', all AI workflows completed'}`,
       );
     } catch (error) {
       this.logger.error(
@@ -669,5 +676,10 @@ export class WorkflowQueueHandler implements OnModuleInit {
     ).getTime();
 
     return Number.isFinite(timestamp) ? timestamp : 0;
+  }
+
+  private isFirst2FinishChallenge(typeName?: string): boolean {
+    const normalized = (typeName ?? '').trim().toLowerCase();
+    return normalized === 'first2finish' || normalized === 'first 2 finish';
   }
 }

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -504,6 +504,7 @@ export class WorkflowQueueHandler implements OnModuleInit {
   async getInProgressAiWorkflowRunCount(
     challengeId: string,
     aiWorkflowIds: string[],
+    submissionId?: string,
   ): Promise<number> {
     if (!aiWorkflowIds || aiWorkflowIds.length === 0) {
       return 0;
@@ -515,9 +516,12 @@ export class WorkflowQueueHandler implements OnModuleInit {
       where: {
         workflowId: { in: aiWorkflowIds },
         status: { in: inProgressStatuses },
-        submission: {
-          challengeId,
-        },
+        submissionId: submissionId || undefined,
+        submission: submissionId
+          ? undefined
+          : {
+              challengeId,
+            },
       },
     });
 
@@ -531,11 +535,18 @@ export class WorkflowQueueHandler implements OnModuleInit {
   private async areAllAiWorkflowsComplete(
     challengeId: string,
     aiWorkflowIds: string[],
+    submissionId?: string,
   ): Promise<boolean> {
+    if (!aiWorkflowIds || aiWorkflowIds.length === 0) {
+      return true;
+    }
+
     const inProgressCount = await this.getInProgressAiWorkflowRunCount(
       challengeId,
       aiWorkflowIds,
+      submissionId,
     );
+
     return inProgressCount === 0;
   }
 
@@ -600,9 +611,23 @@ export class WorkflowQueueHandler implements OnModuleInit {
 
       // For F2F challenges, publish immediately per-submission without waiting for all workflows.
       // The autopilot will close the AI Screening phase and process submissions one at a time.
+      // We still need to ensure all workflows for this submission have completed.
       const isF2F = this.isFirst2FinishChallenge(challenge.type);
 
-      if (!isF2F) {
+      if (isF2F) {
+        const submissionComplete = await this.areAllAiWorkflowsComplete(
+          challengeId,
+          aiWorkflowIds,
+          submissionId,
+        );
+
+        if (!submissionComplete) {
+          this.logger.debug(
+            `[publishAiWorkflowPhaseCompletedEvent] Not all AI workflows complete for submission ${submissionId} in challenge ${challengeId}`,
+          );
+          return;
+        }
+      } else {
         // For non-F2F challenges, wait for all AI workflows to complete
         const allComplete = await this.areAllAiWorkflowsComplete(
           challengeId,

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -680,6 +680,6 @@ export class WorkflowQueueHandler implements OnModuleInit {
 
   private isFirst2FinishChallenge(typeName?: string): boolean {
     const normalized = (typeName ?? '').trim().toLowerCase();
-    return normalized === 'first2finish' || normalized === 'first 2 finish';
+    return normalized === 'first2finish';
   }
 }


### PR DESCRIPTION
* Modified `publishAiWorkflowPhaseCompletedEvent` in `workflow-queue.handler.ts` to publish completion events immediately per submission for F2F challenges, while retaining the "wait for all workflows" behavior for non-F2F challenges. 
This is also handled in autopilot - it will allow ai screening phase to close immediately and not await for all submissions screening to finish.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/review-api-v6/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
