### PR TITLE
Improve appeals endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ workflows:
                               - pm-4172_2
                               - PM-4347_allow-creators-to-edit-ai-configs
                               - PM-4507
+                              - improve-appeals-endpoint
 
             - 'build-prod':
                   context: org-global

--- a/src/api/appeal/appeal.controller.ts
+++ b/src/api/appeal/appeal.controller.ts
@@ -33,6 +33,17 @@ import { Roles } from 'src/shared/guards/tokenRoles.guard';
 import { JwtUser } from 'src/shared/modules/global/jwt.service';
 import { AppealService } from './appeal.service';
 
+function parseCsvIds(value?: string): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
 @ApiTags('Appeal')
 @ApiBearerAuth()
 @Controller('/appeals')
@@ -188,6 +199,16 @@ export class AppealController {
     description: 'The ID of the review to filter by',
     required: false,
   })
+  @ApiQuery({
+    name: 'reviewIds',
+    description: 'Comma-separated list of review IDs to filter by',
+    required: false,
+  })
+  @ApiQuery({
+    name: 'challengeId',
+    description: 'The challenge ID to filter by',
+    required: false,
+  })
   @ApiResponse({
     status: 200,
     description: 'List of matching appeals',
@@ -197,8 +218,19 @@ export class AppealController {
   async getAppeals(
     @Query('resourceId') resourceId?: string,
     @Query('reviewId') reviewId?: string,
+    @Query('reviewIds') reviewIds?: string,
+    @Query('challengeId') challengeId?: string,
     @Query() paginationDto?: PaginationDto,
   ): Promise<PaginatedResponse<AppealResponseDto>> {
-    return this.appealService.getAppeals(resourceId, reviewId, paginationDto);
+    const normalizedReviewIds = Array.from(
+      new Set([reviewId, ...parseCsvIds(reviewIds)].filter(Boolean)),
+    ) as string[];
+
+    return this.appealService.getAppeals(
+      resourceId,
+      normalizedReviewIds,
+      challengeId,
+      paginationDto,
+    );
   }
 }

--- a/src/api/appeal/appeal.service.spec.ts
+++ b/src/api/appeal/appeal.service.spec.ts
@@ -10,6 +10,8 @@ import { CommonConfig } from 'src/shared/config/common.config';
 
 const prismaMock = {
   appeal: {
+    count: jest.fn(),
+    findMany: jest.fn(),
     findUnique: jest.fn(),
     findUniqueOrThrow: jest.fn(),
     update: jest.fn(),
@@ -877,5 +879,121 @@ describe('AppealService.createAppealResponse', () => {
       `creating response for appeal ${baseAppeal.id}`,
     );
     expect(eventBusServiceMock.publish).not.toHaveBeenCalled();
+  });
+});
+
+describe('AppealService.getAppeals', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    prismaErrorServiceMock.handleError.mockImplementation((error: any) => {
+      throw error;
+    });
+  });
+
+  it('supports filtering by multiple reviewIds and challengeId', async () => {
+    prismaMock.appeal.findMany.mockResolvedValue([
+      {
+        id: 'appeal-1',
+        resourceId: 'resource-1',
+        reviewItemCommentId: 'comment-1',
+        content: 'Appeal content',
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        createdBy: 'user-1',
+        updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+        updatedBy: 'user-2',
+        legacyId: null,
+        appealResponse: null,
+        reviewItemComment: {
+          reviewItem: {
+            reviewId: 'review-1',
+          },
+        },
+      },
+    ]);
+    prismaMock.appeal.count.mockResolvedValue(1);
+
+    const result = await service.getAppeals(
+      undefined,
+      ['review-1', 'review-2'],
+      'challenge-1',
+      { page: 2, perPage: 20 },
+    );
+
+    expect(prismaMock.appeal.findMany).toHaveBeenCalledWith({
+      where: {
+        reviewItemComment: {
+          reviewItem: {
+            reviewId: { in: ['review-1', 'review-2'] },
+            review: {
+              submission: {
+                challengeId: 'challenge-1',
+              },
+            },
+          },
+        },
+      },
+      skip: 20,
+      take: 20,
+      orderBy: {
+        createdAt: 'desc',
+      },
+      select: expect.objectContaining({
+        reviewItemComment: {
+          select: {
+            reviewItem: {
+              select: {
+                reviewId: true,
+              },
+            },
+          },
+        },
+      }),
+    });
+    expect(prismaMock.appeal.count).toHaveBeenCalledWith({
+      where: {
+        reviewItemComment: {
+          reviewItem: {
+            reviewId: { in: ['review-1', 'review-2'] },
+            review: {
+              submission: {
+                challengeId: 'challenge-1',
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      data: [
+        {
+          id: 'appeal-1',
+          reviewId: 'review-1',
+        },
+      ],
+      meta: {
+        page: 2,
+        perPage: 20,
+        totalCount: 1,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it('keeps the simpler resourceId filter path when no review filters are provided', async () => {
+    prismaMock.appeal.findMany.mockResolvedValue([]);
+    prismaMock.appeal.count.mockResolvedValue(0);
+
+    await service.getAppeals('resource-1', [], undefined, {
+      page: 1,
+      perPage: 10,
+    });
+
+    expect(prismaMock.appeal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          resourceId: 'resource-1',
+        },
+      }),
+    );
   });
 });

--- a/src/api/appeal/appeal.service.ts
+++ b/src/api/appeal/appeal.service.ts
@@ -5,6 +5,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { Resource } from '@prisma/client-resource';
 import {
   AppealRequestDto,
@@ -821,24 +822,41 @@ export class AppealService {
 
   async getAppeals(
     resourceId?: string,
-    reviewId?: string,
+    reviewIds: string[] = [],
+    challengeId?: string,
     paginationDto?: PaginationDto,
   ): Promise<PaginatedResponse<AppealResponseDto>> {
     this.logger.log(
-      `Getting appeals with filters - resourceId: ${resourceId}, reviewId: ${reviewId}`,
+      `Getting appeals with filters - resourceId: ${resourceId}, reviewIds: ${reviewIds.join(',')}, challengeId: ${challengeId}`,
     );
 
     const { page = 1, perPage = 10 } = paginationDto || {};
     const skip = (page - 1) * perPage;
 
     try {
-      const whereClause: any = {};
-      if (resourceId) whereClause.resourceId = resourceId;
-      if (reviewId) {
-        whereClause.reviewItemComment = {
-          reviewItem: {
-            reviewId: reviewId,
+      const whereClause: Prisma.appealWhereInput = {};
+      if (resourceId) {
+        whereClause.resourceId = resourceId;
+      }
+
+      const reviewItemWhere: Prisma.reviewItemWhereInput = {};
+      if (reviewIds.length === 1) {
+        reviewItemWhere.reviewId = reviewIds[0];
+      } else if (reviewIds.length > 1) {
+        reviewItemWhere.reviewId = { in: reviewIds };
+      }
+
+      if (challengeId) {
+        reviewItemWhere.review = {
+          submission: {
+            challengeId,
           },
+        };
+      }
+
+      if (Object.keys(reviewItemWhere).length > 0) {
+        whereClause.reviewItemComment = {
+          reviewItem: reviewItemWhere,
         };
       }
 
@@ -873,6 +891,15 @@ export class AppealService {
                 updatedBy: true,
               },
             },
+            reviewItemComment: {
+              select: {
+                reviewItem: {
+                  select: {
+                    reviewId: true,
+                  },
+                },
+              },
+            },
           },
         }),
         this.prisma.appeal.count({
@@ -895,6 +922,7 @@ export class AppealService {
           updatedAt: appeal.updatedAt,
           updatedBy: appeal.updatedBy,
           legacyId: appeal.legacyId,
+          reviewId: appeal.reviewItemComment.reviewItem.reviewId,
           // Include appealResponse so clients can tell whether an appeal
           // has been responded to. This field was previously omitted,
           // which caused Remaining counts to be incorrect in Platform UI.
@@ -922,7 +950,7 @@ export class AppealService {
     } catch (error) {
       const errorResponse = this.prismaErrorService.handleError(
         error,
-        `fetching appeals with filters - resourceId: ${resourceId}, reviewId: ${reviewId}`,
+        `fetching appeals with filters - resourceId: ${resourceId}, reviewIds: ${reviewIds.join(',')}, challengeId: ${challengeId}`,
       );
 
       throw new InternalServerErrorException({

--- a/src/dto/appeal.dto.ts
+++ b/src/dto/appeal.dto.ts
@@ -104,6 +104,13 @@ export class AppealResponseDto extends AppealBaseDto {
   id: string;
 
   @ApiProperty({
+    description: 'The review ID associated with this appeal',
+    example: 'review123',
+    required: false,
+  })
+  reviewId?: string;
+
+  @ApiProperty({
     description: 'The associated appeal response (optional)',
     type: AppealResponseResponseDto,
     required: false,


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-4878

- The `getAppeals` endpoint now accepts a comma-separated list of review IDs (`reviewIds`) and a `challengeId` as query parameters, in addition to the existing `resourceId` and single `reviewId` filters. This allows clients to retrieve appeals related to multiple reviews or a specific challenge. 
- The appeal response DTO now includes the `reviewId` associated with each appeal, making it easier for clients to correlate appeals with their reviews. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/review-api-v6/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
