### PR TITLE
PM-4867 - add flag to allow ai workflows disable

### DIFF
--- a/prisma/challenge-schema.prisma
+++ b/prisma/challenge-schema.prisma
@@ -627,7 +627,7 @@ model DefaultChallengeReviewer {
   baseCoefficient           Float?
   incrementalCoefficient    Float?
   opportunityType     ReviewOpportunityTypeEnum?
-  aiWorkflowId        String?
+  aiConfigTemplateId        String?
 
   // Relations
   challengeType  ChallengeType  @relation(fields: [typeId], references: [id])

--- a/prisma/migrations/20260417120000_add_disabled_flags_to_ai_configuration/migration.sql
+++ b/prisma/migrations/20260417120000_add_disabled_flags_to_ai_configuration/migration.sql
@@ -1,0 +1,6 @@
+-- Add runtime enable/disable flags for AI configuration entities.
+ALTER TABLE "aiWorkflow"
+ADD COLUMN "disabled" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "aiReviewTemplateConfig"
+ADD COLUMN "disabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -708,6 +708,7 @@ model aiWorkflow {
   gitWorkflowId String   @db.VarChar
   gitOwnerRepo  String   @db.VarChar
   scorecardId String   @db.VarChar(14)
+  disabled    Boolean  @default(false)
   createdAt   DateTime @default(now()) @db.Timestamp(3)
   createdBy   String?  @db.Text
   updatedAt   DateTime @updatedAt
@@ -815,6 +816,7 @@ model aiReviewTemplateConfig {
   mode               AiReviewMode  @default(AI_GATING)
   autoFinalize       Boolean       @default(false)
   formula            Json?
+  disabled           Boolean       @default(false)
 
   createdAt          DateTime      @default(now())
   createdBy          String?

--- a/src/api/ai-review-config/ai-review-config.service.ts
+++ b/src/api/ai-review-config/ai-review-config.service.ts
@@ -57,6 +57,7 @@ const CONFIG_INCLUDE = {
 
 type AiReviewConfigTemplateSource = {
   id: string;
+  disabled: boolean;
   minPassingThreshold: Prisma.Decimal | number | string | null;
   mode: PrismaAiReviewMode;
   autoFinalize: boolean;
@@ -285,16 +286,28 @@ export class AiReviewConfigService {
     }
   }
 
-  private async validateWorkflowIdsExist(workflowIds: string[]): Promise<void> {
+  private async validateWorkflowIdsExistAndActive(
+    workflowIds: string[],
+  ): Promise<void> {
     const found = await this.prisma.aiWorkflow.findMany({
       where: { id: { in: workflowIds } },
-      select: { id: true },
+      select: { id: true, disabled: true },
     });
-    const foundIds = new Set(found.map((w) => w.id));
-    const missing = workflowIds.filter((id) => !foundIds.has(id));
+
+    const foundById = new Map(found.map((workflow) => [workflow.id, workflow]));
+    const missing = workflowIds.filter((id) => !foundById.has(id));
     if (missing.length > 0) {
       throw new BadRequestException(
         `Workflow(s) not found: ${missing.join(', ')}`,
+      );
+    }
+
+    const disabled = workflowIds.filter(
+      (id) => foundById.get(id)?.disabled === true,
+    );
+    if (disabled.length > 0) {
+      throw new BadRequestException(
+        `Workflow(s) are disabled and cannot be used: ${disabled.join(', ')}`,
       );
     }
   }
@@ -408,8 +421,13 @@ export class AiReviewConfigService {
           `Template with id ${dto.templateId} not found.`,
         );
       }
+      if (template.disabled) {
+        throw new BadRequestException(
+          `Template with id ${dto.templateId} is disabled and cannot be used.`,
+        );
+      }
       const templateWorkflowIds = template.workflows.map((w) => w.workflowId);
-      await this.validateWorkflowIdsExist(templateWorkflowIds);
+      await this.validateWorkflowIdsExistAndActive(templateWorkflowIds);
       payload = {
         challengeId: dto.challengeId,
         minPassingThreshold:
@@ -435,7 +453,7 @@ export class AiReviewConfigService {
       throw new BadRequestException('At least one workflow is required.');
     }
     this.validateNoDuplicateWorkflowIds(payload.workflows);
-    await this.validateWorkflowIdsExist(
+    await this.validateWorkflowIdsExistAndActive(
       payload.workflows.map((w) => w.workflowId),
     );
     this.validateWeightsSumTo100(payload.workflows);
@@ -541,9 +559,28 @@ export class AiReviewConfigService {
     if (rest.templateId !== undefined)
       configData.templateId = rest.templateId || null;
 
+    if (rest.templateId?.trim()) {
+      const template = await this.prisma.aiReviewTemplateConfig.findUnique({
+        where: { id: rest.templateId.trim() },
+        select: { id: true, disabled: true },
+      });
+      if (!template) {
+        throw new NotFoundException(
+          `Template with id ${rest.templateId} not found.`,
+        );
+      }
+      if (template.disabled) {
+        throw new BadRequestException(
+          `Template with id ${rest.templateId} is disabled and cannot be used.`,
+        );
+      }
+    }
+
     if (workflows !== undefined && workflows.length > 0) {
       this.validateNoDuplicateWorkflowIds(workflows);
-      await this.validateWorkflowIdsExist(workflows.map((w) => w.workflowId));
+      await this.validateWorkflowIdsExistAndActive(
+        workflows.map((w) => w.workflowId),
+      );
       this.validateWeightsSumTo100(workflows);
 
       await this.prisma.$transaction(async (tx) => {

--- a/src/api/ai-review-template/ai-review-template.service.ts
+++ b/src/api/ai-review-template/ai-review-template.service.ts
@@ -63,6 +63,7 @@ type AiReviewTemplateRecord = {
   mode: PrismaAiReviewMode;
   autoFinalize: boolean;
   formula: Prisma.JsonValue | null;
+  disabled: boolean;
   createdAt: Date;
   updatedAt: Date;
   workflows: AiReviewTemplateWorkflowRecord[];
@@ -115,6 +116,7 @@ export class AiReviewTemplateService {
       mode: this.mapModeToResponse(template.mode),
       autoFinalize: template.autoFinalize,
       formula,
+      disabled: template.disabled,
       createdAt: template.createdAt,
       updatedAt: template.updatedAt,
       workflows: template.workflows.map((workflow) =>
@@ -198,6 +200,46 @@ export class AiReviewTemplateService {
     );
   }
 
+  private async validateWorkflowIdsExistAndActive(
+    workflowIds: string[],
+  ): Promise<void> {
+    const found = await this.prisma.aiWorkflow.findMany({
+      where: { id: { in: workflowIds } },
+      select: { id: true, disabled: true },
+    });
+
+    const foundById = new Map(found.map((workflow) => [workflow.id, workflow]));
+    const missing = workflowIds.filter((id) => !foundById.has(id));
+    if (missing.length > 0) {
+      throw new BadRequestException(
+        `Workflow(s) not found: ${missing.join(', ')}`,
+      );
+    }
+
+    const disabled = workflowIds.filter(
+      (id) => foundById.get(id)?.disabled === true,
+    );
+    if (disabled.length > 0) {
+      throw new BadRequestException(
+        `Workflow(s) are disabled and cannot be used: ${disabled.join(', ')}`,
+      );
+    }
+  }
+
+  private async removeDefaultChallengeReviewersForTemplateIds(
+    templateIds: string[],
+  ): Promise<void> {
+    if (!templateIds.length) {
+      return;
+    }
+
+    await this.challengePrisma.$executeRaw`
+      DELETE FROM "DefaultChallengeReviewer"
+      WHERE "isMemberReview" = false
+        AND "aiConfigTemplateId" IN (${Prisma.join(templateIds)})
+    `;
+  }
+
   async create(
     dto: CreateAiReviewTemplateConfigDto,
   ): Promise<AiReviewTemplateConfigResponseDto> {
@@ -214,17 +256,7 @@ export class AiReviewTemplateService {
 
     this.validateNoDuplicateWorkflowIds(dto.workflows);
 
-    const found = await this.prisma.aiWorkflow.findMany({
-      where: { id: { in: workflowIds } },
-      select: { id: true },
-    });
-    const foundIds = new Set(found.map((w) => w.id));
-    const missing = workflowIds.filter((id) => !foundIds.has(id));
-    if (missing.length > 0) {
-      throw new BadRequestException(
-        `Workflow(s) not found: ${missing.join(', ')}`,
-      );
-    }
+    await this.validateWorkflowIdsExistAndActive(workflowIds);
 
     this.validateWeightsSumTo100(dto.workflows);
 
@@ -253,6 +285,7 @@ export class AiReviewTemplateService {
           configData.formula != null
             ? (configData.formula as Prisma.InputJsonValue)
             : undefined,
+        disabled: configData.disabled ?? false,
       },
     });
 
@@ -306,7 +339,16 @@ export class AiReviewTemplateService {
     id: string,
     dto: UpdateAiReviewTemplateConfigDto,
   ): Promise<AiReviewTemplateConfigResponseDto> {
-    await this.findById(id);
+    const existing = await this.prisma.aiReviewTemplateConfig.findUnique({
+      where: { id },
+      select: { id: true, disabled: true },
+    });
+    if (!existing) {
+      this.logger.error(`AI review template with id ${id} not found.`);
+      throw new NotFoundException(
+        `AI review template with id ${id} not found.`,
+      );
+    }
 
     if (dto.formula !== undefined) {
       this.validateFormulaNotEmpty(dto.formula);
@@ -327,21 +369,12 @@ export class AiReviewTemplateService {
       configData.autoFinalize = rest.autoFinalize;
     if (rest.formula !== undefined)
       configData.formula = rest.formula as Prisma.InputJsonValue;
+    if (rest.disabled !== undefined) configData.disabled = rest.disabled;
 
     if (workflows !== undefined) {
       this.validateNoDuplicateWorkflowIds(workflows);
       const workflowIds = workflows.map((w) => w.workflowId);
-      const found = await this.prisma.aiWorkflow.findMany({
-        where: { id: { in: workflowIds } },
-        select: { id: true },
-      });
-      const foundIds = new Set(found.map((w) => w.id));
-      const missing = workflowIds.filter((id) => !foundIds.has(id));
-      if (missing.length > 0) {
-        throw new BadRequestException(
-          `Workflow(s) not found: ${missing.join(', ')}`,
-        );
-      }
+      await this.validateWorkflowIdsExistAndActive(workflowIds);
 
       this.validateWeightsSumTo100(workflows);
 
@@ -369,6 +402,10 @@ export class AiReviewTemplateService {
         where: { id },
         data: configData,
       });
+    }
+
+    if (!existing.disabled && dto.disabled === true) {
+      await this.removeDefaultChallengeReviewersForTemplateIds([id]);
     }
 
     return this.findById(id);

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -29,7 +29,8 @@ import { LoggerService } from 'src/shared/modules/global/logger.service';
 import { GiteaService } from 'src/shared/modules/global/gitea.service';
 import { MemberPrismaService } from 'src/shared/modules/global/member-prisma.service';
 import { QueueSchedulerService } from 'src/shared/modules/global/queue-scheduler.service';
-import { VoteType } from '@prisma/client';
+import { Prisma, VoteType } from '@prisma/client';
+import { ChallengePrismaService } from 'src/shared/modules/global/challenge-prisma.service';
 
 @Injectable()
 export class AiWorkflowService {
@@ -42,8 +43,23 @@ export class AiWorkflowService {
     private readonly resourceApiService: ResourceApiService,
     private readonly giteaService: GiteaService,
     private readonly scheduler: QueueSchedulerService,
+    private readonly challengePrisma: ChallengePrismaService,
   ) {
     this.logger = LoggerService.forRoot('AiWorkflowService');
+  }
+
+  private async removeDefaultChallengeReviewersForTemplateIds(
+    templateIds: string[],
+  ): Promise<void> {
+    if (!templateIds.length) {
+      return;
+    }
+
+    await this.challengePrisma.$executeRaw`
+      DELETE FROM "DefaultChallengeReviewer"
+      WHERE "isMemberReview" = false
+        AND "aiConfigTemplateId" IN (${Prisma.join(templateIds)})
+    `;
   }
 
   async retriggerWorkflowRun(workflowRunId: string) {
@@ -75,6 +91,12 @@ export class AiWorkflowService {
     if (!existingRun.submission?.challengeId) {
       throw new InternalServerErrorException(
         `Challenge ID not found for submission ${existingRun.submissionId}.`,
+      );
+    }
+
+    if (existingRun.workflow?.disabled) {
+      throw new BadRequestException(
+        `Workflow ${existingRun.workflowId} is disabled and cannot be retriggered.`,
       );
     }
 
@@ -363,6 +385,7 @@ export class AiWorkflowService {
           name,
           scorecardId,
           llmId,
+          disabled: createAiWorkflowDto.disabled ?? false,
         },
       })
       .catch((e) => {
@@ -456,10 +479,53 @@ export class AiWorkflowService {
       }
     }
 
-    return this.prisma.aiWorkflow.update({
-      where: { id },
-      data: updateDto,
+    let disabledTemplateIds: string[] = [];
+
+    const updatedWorkflow = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.aiWorkflow.update({
+        where: { id },
+        data: updateDto,
+      });
+
+      if (!existingWorkflow.disabled && updateDto.disabled === true) {
+        const affectedTemplates = await tx.aiReviewTemplateConfig.findMany({
+          where: {
+            disabled: false,
+            workflows: {
+              some: {
+                workflowId: id,
+              },
+            },
+          },
+          select: {
+            id: true,
+          },
+        });
+
+        disabledTemplateIds = affectedTemplates.map((template) => template.id);
+
+        await tx.aiReviewTemplateConfig.updateMany({
+          where: {
+            id: {
+              in: disabledTemplateIds,
+            },
+          },
+          data: {
+            disabled: true,
+          },
+        });
+      }
+
+      return updated;
     });
+
+    if (!existingWorkflow.disabled && updateDto.disabled === true) {
+      await this.removeDefaultChallengeReviewersForTemplateIds(
+        disabledTemplateIds,
+      );
+    }
+
+    return updatedWorkflow;
   }
 
   async createRunItemsBatch(workflowId: string, runId: string, items: any[]) {
@@ -523,6 +589,21 @@ export class AiWorkflowService {
 
   async createWorkflowRun(workflowId: string, runData: CreateAiWorkflowRunDto) {
     try {
+      const workflow = await this.prisma.aiWorkflow.findUnique({
+        where: { id: workflowId },
+        select: { id: true, disabled: true },
+      });
+      if (!workflow) {
+        throw new BadRequestException(
+          `Invalid workflow id provided! Workflow with id ${workflowId} does not exist!`,
+        );
+      }
+      if (workflow.disabled) {
+        throw new BadRequestException(
+          `Workflow with id ${workflowId} is disabled and cannot be used.`,
+        );
+      }
+
       const submission = runData.submissionId
         ? await this.prisma.submission.findUnique({
             where: { id: runData.submissionId },

--- a/src/dto/aiReviewTemplateConfig.dto.ts
+++ b/src/dto/aiReviewTemplateConfig.dto.ts
@@ -122,6 +122,15 @@ export class CreateAiReviewTemplateConfigDto {
   formula?: Record<string, unknown>;
 
   @ApiProperty({
+    description: 'Whether this template is disabled',
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  disabled?: boolean;
+
+  @ApiProperty({
     description: 'Workflows linked to this template with weights and gating',
     type: [CreateAiReviewTemplateConfigWorkflowItemDto],
   })
@@ -205,6 +214,9 @@ export class AiReviewTemplateConfigResponseDto {
 
   @ApiProperty({ description: 'Formula configuration', required: false })
   formula?: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Whether this template is disabled' })
+  disabled: boolean;
 
   @ApiProperty({ description: 'Created at' })
   createdAt: Date;

--- a/src/dto/aiWorkflow.dto.ts
+++ b/src/dto/aiWorkflow.dto.ts
@@ -62,6 +62,11 @@ export class CreateAiWorkflowDto {
   @IsString()
   @IsNotEmpty()
   scorecardId: string;
+
+  @ApiProperty({ required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  disabled?: boolean;
 }
 
 export class UpdateAiWorkflowDto extends PartialType(CreateAiWorkflowDto) {}

--- a/src/shared/modules/global/challenge.service.ts
+++ b/src/shared/modules/global/challenge.service.ts
@@ -189,6 +189,7 @@ export class ChallengeApiService {
           SELECT "aiWorkflowId" FROM "ChallengeReviewer"
           WHERE "isMemberReview"=false AND "challengeId" = ${challengeId}
         )
+        AND "disabled" = false
       `;
 
       const metadata = await this.challengePrisma.$queryRaw<

--- a/src/shared/modules/global/submission-scan-complete.orchestrator.ts
+++ b/src/shared/modules/global/submission-scan-complete.orchestrator.ts
@@ -129,11 +129,28 @@ export class SubmissionScanCompleteOrchestrator {
       where: { challengeId },
       orderBy: { version: 'desc' },
       select: {
+        template: {
+          select: {
+            disabled: true,
+          },
+        },
         workflows: {
+          where: {
+            workflow: {
+              disabled: false,
+            },
+          },
           select: { workflowId: true },
         },
       },
     });
+
+    if (config?.template?.disabled) {
+      this.logger.warn(
+        `Skipping AI workflow queueing for challenge ${challengeId} because linked template is disabled.`,
+      );
+      return [];
+    }
 
     return Array.from(
       new Set(

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -86,6 +86,9 @@ export class WorkflowQueueHandler implements OnModuleInit {
     const queues = (
       await this.prisma.aiWorkflow.groupBy({
         by: ['gitWorkflowId'],
+        where: {
+          disabled: false,
+        },
       })
     ).map((d) => d.gitWorkflowId);
 
@@ -100,6 +103,27 @@ export class WorkflowQueueHandler implements OnModuleInit {
     challengeId: string,
     submissionId: string,
   ) {
+    const requestedWorkflowIds = aiWorkflows
+      .map((workflow) => workflow.id)
+      .filter((id): id is string => Boolean(id));
+
+    const activeWorkflows = await this.prisma.aiWorkflow.findMany({
+      where: {
+        id: { in: requestedWorkflowIds },
+        disabled: false,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (!activeWorkflows.length) {
+      this.logger.log(
+        `No active AI workflows to queue for challenge ${challengeId}, submission ${submissionId}.`,
+      );
+      return;
+    }
+
     await this.prisma.$transaction(async (tx) => {
       // get a lock for the challengeId, submissionId pair
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(${stringToHash(`queueWorkflowRuns, ${challengeId}:${submissionId}`)})`;
@@ -115,7 +139,7 @@ export class WorkflowQueueHandler implements OnModuleInit {
       }
 
       const workflowRuns = await tx.aiWorkflowRun.createManyAndReturn({
-        data: aiWorkflows.map((workflow) => ({
+        data: activeWorkflows.map((workflow) => ({
           workflowId: workflow.id,
           submissionId,
           status: 'INIT',
@@ -170,6 +194,25 @@ export class WorkflowQueueHandler implements OnModuleInit {
     const workflow = await this.prisma.aiWorkflow.findUniqueOrThrow({
       where: { id: (job.data as { workflowId: string })?.workflowId },
     });
+
+    if (workflow.disabled) {
+      const queuedRunId = (job.data as { jobId?: string })?.jobId;
+      if (queuedRunId) {
+        await this.prisma.aiWorkflowRun.update({
+          where: { id: queuedRunId },
+          data: {
+            status: 'CANCELLED',
+            completedAt: new Date(),
+          },
+        });
+      }
+
+      this.logger.warn(
+        `Skipping dispatch for disabled workflow ${workflow.id}. job=${job.id}`,
+      );
+      return;
+    }
+
     const workflowRun = await this.prisma.aiWorkflowRun.findUniqueOrThrow({
       where: { id: (job.data as { jobId: string })?.jobId },
     });

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -86,9 +86,6 @@ export class WorkflowQueueHandler implements OnModuleInit {
     const queues = (
       await this.prisma.aiWorkflow.groupBy({
         by: ['gitWorkflowId'],
-        where: {
-          disabled: false,
-        },
       })
     ).map((d) => d.gitWorkflowId);
 


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-4867

**Database schema and model changes:**
- Added a `disabled` boolean column (default `false`) to both the `aiWorkflow` and `aiReviewTemplateConfig` tables and models, allowing workflows and templates to be enabled or disabled at runtime. 
- Changed the field in `DefaultChallengeReviewer` from `aiWorkflowId` to `aiConfigTemplateId` to align with template-based configuration.

**API validation and enforcement:**
- Updated service logic to prevent use of disabled workflows or templates in configuration creation, update, and execution. This includes new validation methods that check for both existence and enabled status, and throw exceptions if disabled entities are referenced. 

**Cascading disables and cleanup:**
- When an AI workflow is disabled, all active templates using that workflow are also disabled, and related default challenge reviewers are removed to maintain data consistency.
- 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/review-api-v6/pull/248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
