### PR TITLE
Allow setting gitRunId even when workflowRun is in "queued" state

### DIFF
--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -305,7 +305,10 @@ export class WorkflowQueueHandler implements OnModuleInit {
         },
       });
 
-      if (!aiWorkflowRun || aiWorkflowRun.status !== 'DISPATCHED') {
+      if (
+        !aiWorkflowRun ||
+        !['DISPATCHED', 'QUEUED'].includes(aiWorkflowRun.status)
+      ) {
         this.logger.error(
           `Workflow run with id ${aiWorkflowRunId} is not in DISPATCHED status or not found. Status: ${aiWorkflowRun?.status}`,
         );

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -310,7 +310,7 @@ export class WorkflowQueueHandler implements OnModuleInit {
         !['DISPATCHED', 'QUEUED'].includes(aiWorkflowRun.status)
       ) {
         this.logger.error(
-          `Workflow run with id ${aiWorkflowRunId} is not in DISPATCHED status or not found. Status: ${aiWorkflowRun?.status}`,
+          `Workflow run with id ${aiWorkflowRunId} is not in DISPATCHED or QUEUED status or not found. Status: ${aiWorkflowRun?.status}`,
         );
         return;
       }


### PR DESCRIPTION
This pull request updates the status check logic in the `WorkflowQueueHandler` to allow workflow runs with either `DISPATCHED` or `QUEUED` status to proceed, instead of only `DISPATCHED`. This change improves the flexibility of the workflow queue handling.
