### PR TITLE
Fix how dispatched status is set

### DIFF
--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -214,16 +214,35 @@ export class WorkflowQueueHandler implements OnModuleInit {
       where: { id: (job.data as { jobId: string })?.jobId },
     });
 
-    await this.giteaService.runDispatchWorkflow(
-      workflow,
-      workflowRun,
-      (job.data as { params: any })?.params,
-    );
+    const initialStatus = workflowRun.status;
 
     await this.prisma.aiWorkflowRun.update({
       where: { id: workflowRun.id },
       data: {
         status: 'DISPATCHED',
+      },
+    });
+
+    try {
+      await this.giteaService.runDispatchWorkflow(
+        workflow,
+        workflowRun,
+        (job.data as { params: any })?.params,
+      );
+    } catch (error) {
+      await this.prisma.aiWorkflowRun.update({
+        where: { id: workflowRun.id },
+        data: {
+          status: initialStatus,
+        },
+      });
+
+      throw error;
+    }
+
+    await this.prisma.aiWorkflowRun.update({
+      where: { id: workflowRun.id },
+      data: {
         scheduledJobId: job.id,
         completedJobs: 0,
       },


### PR DESCRIPTION
- before starting the git workflow, set status to dispatched, and revert back if the workflow dispatch failed
- this prevents the case where the webhook for workflow "in_progress" is triggered instantly and the aiWorkflowRun status isn't set to "Dispatched" yet.