### PR TITLE
PM-5059: Expose active review submission state

### DIFF
--- a/src/api/my-review/myReview.service.spec.ts
+++ b/src/api/my-review/myReview.service.spec.ts
@@ -44,6 +44,8 @@ describe('MyReviewService', () => {
           currentPhaseActualEnd: null,
           resourceRoleName: null,
           challengeEndDate: future,
+          numOfSubmissions: 2,
+          isIterativeReviewPhaseOpen: true,
           totalReviews: BigInt(4),
           completedReviews: BigInt(2),
           winners: null,
@@ -61,6 +63,8 @@ describe('MyReviewService', () => {
       currentPhaseName: 'Review',
       resourceRoleName: 'Admin',
       reviewProgress: 0.5,
+      numOfSubmissions: 2,
+      isIterativeReviewPhaseOpen: true,
     });
     expect(result.data[0].timeLeftInCurrentPhase).toBeGreaterThan(0);
     expect(result.meta).toEqual({
@@ -322,6 +326,52 @@ describe('MyReviewService', () => {
     expect(sql).toContain('ORDER BY');
     expect(sql).toContain('c.name DESC NULLS LAST');
     expect(sql).toContain('c."createdAt" DESC NULLS LAST');
+  });
+
+  it('returns submission and iterative review phase state for active challenges', async () => {
+    const future = new Date(Date.now() + 60_000);
+
+    challengePrismaMock.$queryRaw
+      .mockResolvedValueOnce([{ total: 1n }])
+      .mockResolvedValueOnce([
+        {
+          challengeId: 'challenge-topgear',
+          challengeName: 'Topgear Task Challenge',
+          challengeTypeId: 'type-topgear',
+          challengeTypeName: 'Topgear Task',
+          currentPhaseName: 'Topgear Submission',
+          currentPhaseScheduledEnd: future,
+          currentPhaseActualEnd: null,
+          resourceRoleName: 'Reviewer',
+          challengeEndDate: future,
+          numOfSubmissions: 3,
+          isIterativeReviewPhaseOpen: false,
+          totalReviews: 0n,
+          completedReviews: 0n,
+          winners: null,
+          status: 'ACTIVE',
+        },
+      ]);
+
+    const result = await service.getMyReviews(
+      { isMachine: false, userId: '151743' },
+      {},
+    );
+
+    expect(result.data[0]).toMatchObject({
+      challengeId: 'challenge-topgear',
+      numOfSubmissions: 3,
+      isIterativeReviewPhaseOpen: false,
+    });
+
+    const rowQuery = challengePrismaMock.$queryRaw.mock.calls[1][0];
+    const sql = rowQuery.inspect().sql.replace(/\s+/g, ' ');
+
+    expect(sql).toContain('c."numOfSubmissions" AS "numOfSubmissions"');
+    expect(sql).toContain(
+      'iterative_review_phase."isIterativeReviewPhaseOpen" AS "isIterativeReviewPhaseOpen"',
+    );
+    expect(sql).toContain("LOWER(p.name) = 'iterative review'");
   });
 
   it('enables time left and challenge end sorting options', async () => {

--- a/src/api/my-review/myReview.service.ts
+++ b/src/api/my-review/myReview.service.ts
@@ -25,6 +25,8 @@ interface ChallengeSummaryRow {
   currentPhaseActualEnd: Date | null;
   resourceRoleName: string | null;
   challengeEndDate: Date | null;
+  numOfSubmissions: number | null;
+  isIterativeReviewPhaseOpen: boolean | null;
   totalReviews: bigint | null;
   completedReviews: bigint | null;
   winners: Prisma.JsonValue | null;
@@ -455,6 +457,20 @@ export class MyReviewService {
       `,
     );
 
+    metricJoins.push(
+      Prisma.sql`
+        LEFT JOIN LATERAL (
+          SELECT
+            TRUE AS "isIterativeReviewPhaseOpen"
+          FROM challenges."ChallengePhase" p
+          WHERE p."challengeId" = c.id
+            AND LOWER(p.name) = 'iterative review'
+            AND p."isOpen" IS TRUE
+          LIMIT 1
+        ) iterative_review_phase ON TRUE
+      `,
+    );
+
     const joinClause = joinSqlFragments(
       [...baseJoins, ...metricJoins],
       Prisma.sql``,
@@ -689,6 +705,7 @@ export class MyReviewService {
               r.id AS "resourceId",
               rr.name AS "resourceRoleName",
               c."endDate" AS "challengeEndDate",
+              c."numOfSubmissions" AS "numOfSubmissions",
               c."createdAt" AS "challengeCreatedAt",
               c.status AS "status"
             FROM challenges."Challenge" c
@@ -720,6 +737,8 @@ export class MyReviewService {
           cp."actualEndDate" AS "currentPhaseActualEnd",
           bp."resourceRoleName" AS "resourceRoleName",
           bp."challengeEndDate" AS "challengeEndDate",
+          bp."numOfSubmissions" AS "numOfSubmissions",
+          iterative_review_phase."isIterativeReviewPhaseOpen" AS "isIterativeReviewPhaseOpen",
           review_totals."totalReviews" AS "totalReviews",
           review_totals."completedReviews" AS "completedReviews",
           cw.winners AS "winners",
@@ -775,6 +794,15 @@ export class MyReviewService {
             AND cr."aiWorkflowId" IS NOT NULL
           LIMIT 1
         ) cr ON TRUE
+        LEFT JOIN LATERAL (
+          SELECT
+            TRUE AS "isIterativeReviewPhaseOpen"
+          FROM challenges."ChallengePhase" p
+          WHERE p."challengeId" = bp."challengeId"
+            AND LOWER(p.name) = 'iterative review'
+            AND p."isOpen" IS TRUE
+          LIMIT 1
+        ) iterative_review_phase ON TRUE
         ORDER BY ${pastFinalOrderClause}
       `
         : Prisma.sql`
@@ -796,6 +824,7 @@ export class MyReviewService {
               r.id AS "resourceId",
               rr.name AS "resourceRoleName",
               c."endDate" AS "challengeEndDate",
+              c."numOfSubmissions" AS "numOfSubmissions",
               c."createdAt" AS "challengeCreatedAt",
               c.status AS "status"
             FROM member_resources r
@@ -826,6 +855,8 @@ export class MyReviewService {
           cp."actualEndDate" AS "currentPhaseActualEnd",
           bp."resourceRoleName" AS "resourceRoleName",
           bp."challengeEndDate" AS "challengeEndDate",
+          bp."numOfSubmissions" AS "numOfSubmissions",
+          iterative_review_phase."isIterativeReviewPhaseOpen" AS "isIterativeReviewPhaseOpen",
           review_totals."totalReviews" AS "totalReviews",
           review_totals."completedReviews" AS "completedReviews",
           cw.winners AS "winners",
@@ -881,6 +912,15 @@ export class MyReviewService {
             AND cr."aiWorkflowId" IS NOT NULL
           LIMIT 1
         ) cr ON TRUE
+        LEFT JOIN LATERAL (
+          SELECT
+            TRUE AS "isIterativeReviewPhaseOpen"
+          FROM challenges."ChallengePhase" p
+          WHERE p."challengeId" = bp."challengeId"
+            AND LOWER(p.name) = 'iterative review'
+            AND p."isOpen" IS TRUE
+          LIMIT 1
+        ) iterative_review_phase ON TRUE
         ORDER BY ${pastFinalOrderClause}
       `;
 
@@ -934,6 +974,8 @@ export class MyReviewService {
           cp."actualEndDate" AS "currentPhaseActualEnd",
           rr.name AS "resourceRoleName",
           c."endDate" AS "challengeEndDate",
+          c."numOfSubmissions" AS "numOfSubmissions",
+          iterative_review_phase."isIterativeReviewPhaseOpen" AS "isIterativeReviewPhaseOpen",
           review_totals."totalReviews" AS "totalReviews",
           review_totals."completedReviews" AS "completedReviews",
           cw.winners AS "winners",
@@ -1045,6 +1087,8 @@ export class MyReviewService {
         timeLeftInCurrentPhase: timeLeftSeconds,
         resourceRoleName: row.resourceRoleName ?? adminRoleLabel,
         reviewProgress,
+        numOfSubmissions: row.numOfSubmissions ?? 0,
+        isIterativeReviewPhaseOpen: row.isIterativeReviewPhaseOpen === true,
         winners,
         deliverableDue,
         deliverableDuePhaseName,

--- a/src/dto/my-review.dto.ts
+++ b/src/dto/my-review.dto.ts
@@ -168,6 +168,17 @@ export class MyReviewSummaryDto {
   reviewProgress: number;
 
   @ApiProperty({
+    description: 'Number of submissions recorded for the challenge',
+  })
+  numOfSubmissions: number;
+
+  @ApiProperty({
+    description:
+      'Whether an Iterative Review phase is currently open for the challenge',
+  })
+  isIterativeReviewPhaseOpen: boolean;
+
+  @ApiProperty({
     description:
       'Indicates whether the user has outstanding review deliverables for this challenge',
   })


### PR DESCRIPTION
What was broken
The My Active Challenges review endpoint did not return the number of challenge submissions or whether Iterative Review was currently open, so the review app could not flag Topgear Task challenges where submitted work was waiting but Iterative Review had not opened.

Root cause (if identifiable)
The my-reviews summary query only selected review progress and current phase details; it did not include the challenge submission count or an explicit Iterative Review phase-open signal.

What was changed
Added numOfSubmissions and isIterativeReviewPhaseOpen to the my-reviews DTO and summary query, including active and past query paths.

Any added/updated tests
Added service coverage that verifies the new fields are selected and returned for active review challenges.
