### PR TITLE
PM-4691: assign iterative reviewer role for F2F approvals

### DIFF
--- a/src/api/review-application/reviewApplication.service.spec.ts
+++ b/src/api/review-application/reviewApplication.service.spec.ts
@@ -54,6 +54,19 @@ describe('ReviewApplicationService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    resourcePrismaMock.resource.findFirst.mockResolvedValue(null);
+    resourcePrismaMock.resource.create.mockResolvedValue({ id: 'resource-1' });
+    prismaMock.reviewApplication.update.mockResolvedValue({ id: 'app-1' });
+    memberServiceMock.getUserEmails.mockResolvedValue([
+      { userId: '1001', email: 'reviewer@example.com', handle: 'reviewer' },
+    ]);
+    eventBusServiceMock.sendEmail.mockResolvedValue(undefined);
+    prismaErrorServiceMock.handleError.mockImplementation((error) => ({
+      code: 'TEST_ERROR',
+      details: error,
+      message: error instanceof Error ? error.message : String(error),
+    }));
+
     service = new ReviewApplicationService(
       prismaMock as any,
       challengeServiceMock as any,
@@ -63,6 +76,99 @@ describe('ReviewApplicationService', () => {
       eventBusServiceMock as any,
       prismaErrorServiceMock as any,
     );
+  });
+
+  it('assigns the Iterative Reviewer resource role for F2F iterative review approvals', async () => {
+    prismaMock.reviewApplication.findUnique.mockResolvedValue({
+      id: 'app-iterative',
+      userId: '1001',
+      handle: 'iterative-reviewer',
+      role: ReviewApplicationRole.REVIEWER,
+      status: ReviewApplicationStatus.PENDING,
+      startDate: new Date('2026-05-26T08:33:26.579Z'),
+      opportunityId: 'opp-iterative',
+      createdAt: new Date('2026-05-26T08:42:54.784Z'),
+      opportunity: {
+        id: 'opp-iterative',
+        challengeId: 'challenge-f2f',
+        type: ReviewOpportunityType.REGULAR_REVIEW,
+      },
+    });
+
+    challengePrismaMock.$queryRaw
+      .mockResolvedValueOnce([{ shouldUseIterativeReviewerRole: true }])
+      .mockResolvedValueOnce([]);
+    resourcePrismaMock.resourceRole.findFirst.mockResolvedValue({
+      id: 'iterative-reviewer-role-id',
+      name: 'Iterative Reviewer',
+    });
+    challengeServiceMock.getChallengeDetail.mockResolvedValue({
+      id: 'challenge-f2f',
+      name: 'F2F Challenge',
+    });
+
+    await service.approve('app-iterative');
+
+    expect(resourcePrismaMock.resourceRole.findFirst).toHaveBeenCalledWith({
+      where: { name: 'Iterative Reviewer' },
+    });
+    expect(resourcePrismaMock.resource.create).toHaveBeenCalledWith({
+      data: {
+        challengeId: 'challenge-f2f',
+        createdBy: 'review-api',
+        memberHandle: 'iterative-reviewer',
+        memberId: '1001',
+        roleId: 'iterative-reviewer-role-id',
+      },
+    });
+    expect(prismaMock.reviewApplication.update).toHaveBeenCalledWith({
+      where: { id: 'app-iterative' },
+      data: {
+        status: ReviewApplicationStatus.APPROVED,
+      },
+    });
+  });
+
+  it('keeps the regular Reviewer resource role when no F2F iterative reviewer config exists', async () => {
+    prismaMock.reviewApplication.findUnique.mockResolvedValue({
+      id: 'app-regular',
+      userId: '1001',
+      handle: 'regular-reviewer',
+      role: ReviewApplicationRole.REVIEWER,
+      status: ReviewApplicationStatus.PENDING,
+      startDate: new Date('2026-05-26T08:33:26.579Z'),
+      opportunityId: 'opp-regular',
+      createdAt: new Date('2026-05-26T08:42:54.784Z'),
+      opportunity: {
+        id: 'opp-regular',
+        challengeId: 'challenge-regular',
+        type: ReviewOpportunityType.REGULAR_REVIEW,
+      },
+    });
+
+    challengePrismaMock.$queryRaw
+      .mockResolvedValueOnce([{ shouldUseIterativeReviewerRole: false }])
+      .mockResolvedValueOnce([]);
+    resourcePrismaMock.resourceRole.findFirst.mockResolvedValue({
+      id: 'reviewer-role-id',
+      name: 'Reviewer',
+    });
+    challengeServiceMock.getChallengeDetail.mockResolvedValue({
+      id: 'challenge-regular',
+      name: 'Regular Challenge',
+    });
+
+    await service.approve('app-regular');
+
+    expect(resourcePrismaMock.resourceRole.findFirst).toHaveBeenCalledWith({
+      where: { name: 'Reviewer' },
+    });
+    expect(resourcePrismaMock.resource.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        challengeId: 'challenge-regular',
+        roleId: 'reviewer-role-id',
+      }),
+    });
   });
 
   it('includes past review assignments in rejection email payload', async () => {

--- a/src/api/review-application/reviewApplication.service.ts
+++ b/src/api/review-application/reviewApplication.service.ts
@@ -47,6 +47,10 @@ interface RecentReviewAssignment {
   challengeUrl: string;
 }
 
+interface F2FIterativeReviewerConfigRow {
+  shouldUseIterativeReviewerRole: boolean;
+}
+
 @Injectable()
 export class ReviewApplicationService {
   constructor(
@@ -381,11 +385,7 @@ export class ReviewApplicationService {
       const memberId = String(entity.userId);
       const handle = entity.handle ?? '';
 
-      // Determine the appropriate resource role name using opportunity type with fallback to application role mapping
-      const roleName = this.getResourceRoleName(
-        entity.opportunity.type,
-        entity.role as ReviewApplicationRole,
-      );
+      const roleName = await this.getResourceRoleNameForApproval(entity);
 
       // Resolve role id directly from the Resource DB
       const role = await this.resourcePrisma.resourceRole.findFirst({
@@ -443,6 +443,72 @@ export class ReviewApplicationService {
         details: errorResponse.details,
       });
     }
+  }
+
+  /**
+   * Determine the resource role name used when approving an application.
+   * First2Finish reviewer openings are backed by the Iterative Review phase,
+   * so regular-looking legacy opportunities for those configs must still
+   * assign the Iterative Reviewer resource role.
+   *
+   * @param entity review application with its linked opportunity
+   * @returns resource role name to assign on the challenge
+   */
+  private async getResourceRoleNameForApproval(entity: {
+    role: ReviewApplicationRole | string;
+    opportunity: {
+      challengeId: string;
+      type: ReviewOpportunityType;
+    };
+  }): Promise<string> {
+    const applicationRole = entity.role as ReviewApplicationRole;
+
+    if (
+      entity.opportunity.type === ReviewOpportunityType.REGULAR_REVIEW &&
+      applicationRole === ReviewApplicationRole.REVIEWER &&
+      (await this.hasF2FIterativeReviewerConfig(entity.opportunity.challengeId))
+    ) {
+      return 'Iterative Reviewer';
+    }
+
+    return this.getResourceRoleName(entity.opportunity.type, applicationRole);
+  }
+
+  /**
+   * Check whether a challenge has an open member-reviewer config attached to
+   * the Iterative Review phase on a First2Finish challenge.
+   *
+   * @param challengeId challenge id from the review opportunity
+   * @returns true when approval should assign the Iterative Reviewer role
+   */
+  private async hasF2FIterativeReviewerConfig(
+    challengeId: string,
+  ): Promise<boolean> {
+    const rows = await this.challengePrisma.$queryRaw<
+      F2FIterativeReviewerConfigRow[]
+    >(Prisma.sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM "Challenge" c
+        INNER JOIN "ChallengeType" ct
+          ON ct.id = c."typeId"
+        INNER JOIN "ChallengeReviewer" cr
+          ON cr."challengeId" = c.id
+        INNER JOIN "ChallengePhase" cp
+          ON cp."challengeId" = c.id
+          AND (cp.id = cr."phaseId" OR cp."phaseId" = cr."phaseId")
+        WHERE c.id = ${challengeId}
+          AND (
+            LOWER(ct.name) = 'first2finish'
+            OR LOWER(ct.abbreviation) = 'f2f'
+          )
+          AND LOWER(REPLACE(cp.name, ' ', '')) = 'iterativereview'
+          AND cr."isMemberReview" IS TRUE
+          AND cr."shouldOpenOpportunity" IS NOT FALSE
+      ) AS "shouldUseIterativeReviewerRole"
+    `);
+
+    return rows[0]?.shouldUseIterativeReviewerRole === true;
   }
 
   /**


### PR DESCRIPTION
What was broken
F2F public reviewer applications could still be approved into the generic Reviewer resource role when the stored review opportunity/application looked like a regular review. That left the approved member off the Iterative Review tab.

Root cause
The previous fix only corrected missing review opportunity types during opportunity creation. Work Manager-created F2F challenges can persist a reviewer config on the Iterative Review phase with an explicit REGULAR_REVIEW type, and review-api approval trusted that regular opportunity type when choosing the resource role.

What was changed
Review application approval now detects regular reviewer applications for First2Finish challenges whose member reviewer config is attached to the Iterative Review phase and assigns the Iterative Reviewer resource role. Existing non-F2F regular review approvals continue to assign the Reviewer role.

Any added/updated tests
Added ReviewApplicationService coverage for assigning Iterative Reviewer on F2F iterative review approvals and preserving the regular Reviewer role when the F2F iterative config is not present.
