### PR TITLE
PM-5203 approval phase ai only

### DIFF
--- a/prisma/migrations/20260530120000_add_manager_comment_to_ai_review_decision/migration.sql
+++ b/prisma/migrations/20260530120000_add_manager_comment_to_ai_review_decision/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "aiReviewDecision" ADD COLUMN "managerComment" TEXT;

--- a/prisma/migrations/20260604120000_add_initial_score_to_ai_workflow_run/migration.sql
+++ b/prisma/migrations/20260604120000_add_initial_score_to_ai_workflow_run/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "aiWorkflowRun" ADD COLUMN "initialScore" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -732,6 +732,7 @@ model aiWorkflowRun {
   gitRunId     String    @db.VarChar
   gitRunUrl    String?    @db.Text
   score        Float?    @db.DoublePrecision
+  initialScore Float?    @db.DoublePrecision
   status       String    @db.VarChar
   retryCount   Int       @default(0)
   usage        Json?     @db.JsonB

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -885,6 +885,8 @@ model aiReviewDecision {
   isFinal          Boolean  @default(false)
   finalizedAt      DateTime?
 
+  managerComment   String?  @db.Text
+
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 

--- a/src/api/ai-review-config/ai-review-config.controller.ts
+++ b/src/api/ai-review-config/ai-review-config.controller.ts
@@ -116,7 +116,12 @@ export class AiReviewConfigController {
   }
 
   @Put(':id')
-  @Roles(UserRole.Admin, UserRole.Copilot, UserRole.TalentManager)
+  @Roles(
+    UserRole.Admin,
+    UserRole.Copilot,
+    UserRole.ProjectManager,
+    UserRole.TalentManager,
+  )
   @Scopes(Scope.UpdateAiReviewConfig)
   @ApiOperation({
     summary: 'Update an AI review config',

--- a/src/api/ai-review-config/ai-review-config.controller.ts
+++ b/src/api/ai-review-config/ai-review-config.controller.ts
@@ -36,7 +36,12 @@ export class AiReviewConfigController {
   constructor(private readonly aiReviewConfigService: AiReviewConfigService) {}
 
   @Post()
-  @Roles(UserRole.Admin, UserRole.Copilot, UserRole.TalentManager)
+  @Roles(
+    UserRole.Admin,
+    UserRole.Copilot,
+    UserRole.ProjectManager,
+    UserRole.TalentManager,
+  )
   @Scopes(Scope.CreateAiReviewConfig)
   @ApiOperation({
     summary: 'Create an AI review config',

--- a/src/api/ai-review-decision/ai-review-decision.controller.ts
+++ b/src/api/ai-review-decision/ai-review-decision.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Param, Query, ValidationPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Patch,
+  Body,
+  ValidationPipe,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiTags,
@@ -6,12 +14,14 @@ import {
   ApiResponse,
   ApiParam,
   ApiQuery,
+  ApiBody,
 } from '@nestjs/swagger';
 import { AiReviewDecisionService } from './ai-review-decision.service';
 import {
   ListAiReviewDecisionQueryDto,
   AiReviewDecisionResponseDto,
   AiReviewDecisionStatus,
+  PatchAiReviewDecisionDto,
 } from '../../dto/aiReviewDecision.dto';
 import { Scopes } from 'src/shared/decorators/scopes.decorator';
 import { User } from 'src/shared/decorators/user.decorator';
@@ -113,5 +123,38 @@ export class AiReviewDecisionController {
   @ApiResponse({ status: 404, description: 'AI review decision not found.' })
   async getById(@Param('id') id: string, @User() authUser: JwtUser) {
     return this.aiReviewDecisionService.getById(id, authUser);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.Admin, UserRole.Copilot)
+  @Scopes(Scope.ReadAiReviewDecision)
+  @ApiOperation({
+    summary: 'Update an AI review decision (manager override)',
+    description:
+      'Roles: Admin, Copilot. Allows setting a manager comment and/or per-workflow score overrides. When workflow overrides are provided the total score is recalculated and the status is set to HUMAN_OVERRIDE.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the AI review decision',
+    example: '229c5PnhSKqsSu',
+  })
+  @ApiBody({ type: PatchAiReviewDecisionDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Updated AI review decision.',
+    type: AiReviewDecisionResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden. Only Admins and Copilots may update decisions.',
+  })
+  @ApiResponse({ status: 404, description: 'AI review decision not found.' })
+  async patch(
+    @Param('id') id: string,
+    @Body(new ValidationPipe({ whitelist: true, transform: true }))
+    dto: PatchAiReviewDecisionDto,
+    @User() authUser: JwtUser,
+  ) {
+    return this.aiReviewDecisionService.patch(id, dto, authUser);
   }
 }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -380,6 +380,12 @@ export class AiReviewDecisionService {
           ] as Array<Record<string, unknown>>)
         : [];
 
+      if (!workflows.length) {
+        throw new BadRequestException(
+          'Cannot apply workflow overrides: decision breakdown is missing workflow entries.',
+        );
+      }
+
       const determineRunStatus = (
         workflow: Record<string, unknown>,
         score: number,

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -12,6 +12,7 @@ import {
   ListAiReviewDecisionQueryDto,
   AiReviewDecisionResponseDto,
   AiReviewDecisionStatus,
+  PatchAiReviewDecisionDto,
 } from '../../dto/aiReviewDecision.dto';
 import {
   AiReviewDecisionEscalationResponseDto,
@@ -20,6 +21,7 @@ import {
 import { Prisma } from '@prisma/client';
 import { ChallengeApiService } from 'src/shared/modules/global/challenge.service';
 import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
+import { UserRole } from 'src/shared/enums/userRole.enum';
 
 const DECISION_INCLUDE = {
   config: {
@@ -56,6 +58,7 @@ type AiReviewDecisionRecord = {
   breakdown: Prisma.JsonValue | null;
   isFinal: boolean;
   finalizedAt: Date | null;
+  managerComment: string | null;
   createdAt: Date;
   updatedAt: Date;
   config?: { id: string; challengeId: string; version: number };
@@ -163,6 +166,7 @@ export class AiReviewDecisionService {
       breakdown: row.breakdown as Record<string, unknown> | null,
       isFinal: row.isFinal,
       finalizedAt: row.finalizedAt,
+      managerComment: row.managerComment ?? null,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
       config: row.config as Record<string, unknown>,
@@ -324,5 +328,95 @@ export class AiReviewDecisionService {
     }
 
     return this.mapToResponse(decision);
+  }
+
+  async patch(
+    id: string,
+    dto: PatchAiReviewDecisionDto,
+    authUser: JwtUser,
+  ): Promise<AiReviewDecisionResponseDto> {
+    // Only Admin or Copilot role may update AI review decisions
+    const isPrivileged =
+      authUser.isMachine ||
+      isAdmin(authUser) ||
+      authUser.roles?.includes(UserRole.Copilot);
+    if (!isPrivileged) {
+      throw new ForbiddenException(
+        'Only Admins and Copilots may update AI review decisions.',
+      );
+    }
+
+    const decision = await this.prisma.aiReviewDecision.findUnique({
+      where: { id },
+      include: DECISION_INCLUDE,
+    });
+    if (!decision) {
+      throw new NotFoundException(`AI review decision with id ${id} not found.`);
+    }
+
+    // Build update payload
+    const updateData: Prisma.aiReviewDecisionUpdateInput = {};
+
+    if (dto.managerComment !== undefined) {
+      updateData.managerComment = dto.managerComment;
+    }
+
+    if (dto.workflowOverrides?.length) {
+      // Merge manager overrides into breakdown JSON
+      const currentBreakdown =
+        (decision.breakdown as Record<string, unknown> | null) ?? {};
+      const workflows = Array.isArray(
+        (currentBreakdown as { workflows?: unknown }).workflows,
+      )
+        ? ([...(currentBreakdown as { workflows: unknown[] }).workflows] as Array<
+            Record<string, unknown>
+          >)
+        : [];
+
+      for (const override of dto.workflowOverrides) {
+        const idx = workflows.findIndex(
+          (w) => w['workflowId'] === override.workflowId,
+        );
+        if (idx === -1) continue;
+        if (override.managerScore !== undefined) {
+          workflows[idx] = {
+            ...workflows[idx],
+            managerScore: override.managerScore,
+          };
+        }
+        if (override.workflowComment !== undefined) {
+          workflows[idx] = {
+            ...workflows[idx],
+            managerComment: override.workflowComment,
+          };
+        }
+      }
+
+      updateData.breakdown = { ...currentBreakdown, workflows };
+
+      // Recalculate totalScore from workflows using managerScore ?? runScore
+      const newTotal = workflows.reduce((sum, w) => {
+        const score =
+          w['managerScore'] != null
+            ? Number(w['managerScore'])
+            : w['runScore'] != null
+              ? Number(w['runScore'])
+              : 0;
+        const weight =
+          w['weightPercent'] != null ? Number(w['weightPercent']) : 0;
+        return sum + (score * weight) / 100;
+      }, 0);
+
+      updateData.totalScore = new Prisma.Decimal(newTotal.toFixed(2));
+      updateData.status = 'HUMAN_OVERRIDE';
+    }
+
+    const updated = await this.prisma.aiReviewDecision.update({
+      where: { id },
+      data: updateData,
+      include: DECISION_INCLUDE,
+    });
+
+    return this.mapToResponse(updated as AiReviewDecisionRecord);
   }
 }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -351,7 +351,9 @@ export class AiReviewDecisionService {
       include: DECISION_INCLUDE,
     });
     if (!decision) {
-      throw new NotFoundException(`AI review decision with id ${id} not found.`);
+      throw new NotFoundException(
+        `AI review decision with id ${id} not found.`,
+      );
     }
 
     // Build update payload
@@ -368,9 +370,9 @@ export class AiReviewDecisionService {
       const workflows = Array.isArray(
         (currentBreakdown as { workflows?: unknown }).workflows,
       )
-        ? ([...(currentBreakdown as { workflows: unknown[] }).workflows] as Array<
-            Record<string, unknown>
-          >)
+        ? ([
+            ...(currentBreakdown as { workflows: unknown[] }).workflows,
+          ] as Array<Record<string, unknown>>)
         : [];
 
       for (const override of dto.workflowOverrides) {

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -358,6 +358,7 @@ export class AiReviewDecisionService {
 
     // Build update payload
     const updateData: Prisma.aiReviewDecisionUpdateInput = {};
+    const runUpdates: Array<{ runId: string; managerScore: number }> = [];
 
     if (dto.managerComment !== undefined) {
       updateData.managerComment = dto.managerComment;
@@ -375,6 +376,11 @@ export class AiReviewDecisionService {
           ] as Array<Record<string, unknown>>)
         : [];
 
+      const runUpdates: Array<{
+        runId: string;
+        managerScore: number;
+      }> = [];
+
       for (const override of dto.workflowOverrides) {
         const idx = workflows.findIndex(
           (w) => w['workflowId'] === override.workflowId,
@@ -385,6 +391,17 @@ export class AiReviewDecisionService {
             ...workflows[idx],
             managerScore: override.managerScore,
           };
+
+          let runId: string | null = null;
+          if (typeof workflows[idx]['runId'] === 'string') {
+            runId = workflows[idx]['runId'];
+          }
+          if (runId && override.managerScore !== null) {
+            runUpdates.push({
+              runId,
+              managerScore: override.managerScore,
+            });
+          }
         }
         if (override.workflowComment !== undefined) {
           workflows[idx] = {
@@ -416,10 +433,42 @@ export class AiReviewDecisionService {
       updateData.status = 'HUMAN_OVERRIDE';
     }
 
-    const updated = await this.prisma.aiReviewDecision.update({
-      where: { id },
-      data: updateData,
-      include: DECISION_INCLUDE,
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const updatedDecision = await tx.aiReviewDecision.update({
+        where: { id },
+        data: updateData,
+        include: DECISION_INCLUDE,
+      });
+
+      for (const runUpdate of runUpdates) {
+        const existingRun = await tx.aiWorkflowRun.findUnique({
+          where: { id: runUpdate.runId },
+          select: { score: true, initialScore: true },
+        });
+
+        if (!existingRun) {
+          continue;
+        }
+
+        const aiWorkflowRunUpdate: Prisma.aiWorkflowRunUpdateInput = {
+          score: runUpdate.managerScore,
+        };
+
+        if (
+          existingRun.initialScore === null &&
+          existingRun.score !== null &&
+          existingRun.score !== runUpdate.managerScore
+        ) {
+          aiWorkflowRunUpdate.initialScore = existingRun.score;
+        }
+
+        await tx.aiWorkflowRun.update({
+          where: { id: runUpdate.runId },
+          data: aiWorkflowRunUpdate,
+        });
+      }
+
+      return updatedDecision;
     });
 
     return this.mapToResponse(updated as AiReviewDecisionRecord);

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -358,7 +358,11 @@ export class AiReviewDecisionService {
 
     // Build update payload
     const updateData: Prisma.aiReviewDecisionUpdateInput = {};
-    const runUpdates: Array<{ runId: string; managerScore: number }> = [];
+    const runUpdates: Array<{
+      runId: string;
+      managerScore: number;
+      runStatus: 'SUCCESS' | 'FAILURE';
+    }> = [];
 
     if (dto.managerComment !== undefined) {
       updateData.managerComment = dto.managerComment;
@@ -376,10 +380,16 @@ export class AiReviewDecisionService {
           ] as Array<Record<string, unknown>>)
         : [];
 
-      const runUpdates: Array<{
-        runId: string;
-        managerScore: number;
-      }> = [];
+      const determineRunStatus = (
+        workflow: Record<string, unknown>,
+        score: number,
+      ) => {
+        const minPassing =
+          workflow['minimumPassingScore'] != null
+            ? Number(workflow['minimumPassingScore'])
+            : 0;
+        return score >= minPassing ? 'SUCCESS' : 'FAILURE';
+      };
 
       for (const override of dto.workflowOverrides) {
         const idx = workflows.findIndex(
@@ -400,13 +410,17 @@ export class AiReviewDecisionService {
             runUpdates.push({
               runId,
               managerScore: override.managerScore,
+              runStatus: determineRunStatus(
+                workflows[idx],
+                override.managerScore,
+              ),
             });
           }
         }
         if (override.workflowComment !== undefined) {
           workflows[idx] = {
             ...workflows[idx],
-            managerComment: override.workflowComment,
+            workflowComment: override.workflowComment,
           };
         }
       }
@@ -443,15 +457,20 @@ export class AiReviewDecisionService {
       for (const runUpdate of runUpdates) {
         const existingRun = await tx.aiWorkflowRun.findUnique({
           where: { id: runUpdate.runId },
-          select: { score: true, initialScore: true },
+          select: { score: true, initialScore: true, completedAt: true },
         });
 
         if (!existingRun) {
           continue;
         }
 
-        const aiWorkflowRunUpdate: Prisma.aiWorkflowRunUpdateInput = {
+        const aiWorkflowRunUpdate: Prisma.aiWorkflowRunUpdateInput & {
+          initialScore?: number | null;
+          status?: string;
+          completedAt?: Date | null;
+        } = {
           score: runUpdate.managerScore,
+          status: runUpdate.runStatus,
         };
 
         if (
@@ -460,6 +479,13 @@ export class AiReviewDecisionService {
           existingRun.score !== runUpdate.managerScore
         ) {
           aiWorkflowRunUpdate.initialScore = existingRun.score;
+        }
+
+        if (
+          ['SUCCESS', 'FAILURE'].includes(runUpdate.runStatus) &&
+          existingRun.completedAt == null
+        ) {
+          aiWorkflowRunUpdate.completedAt = new Date();
         }
 
         await tx.aiWorkflowRun.update({

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -394,7 +394,10 @@ export class AiReviewDecisionService {
         }
       }
 
-      updateData.breakdown = { ...currentBreakdown, workflows };
+      updateData.breakdown = {
+        ...currentBreakdown,
+        workflows: workflows as unknown as Prisma.InputJsonObject,
+      };
 
       // Recalculate totalScore from workflows using managerScore ?? runScore
       const newTotal = workflows.reduce((sum, w) => {

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -835,7 +835,6 @@ export class AiWorkflowService {
     try {
       const updateData = { ...patchData } as Prisma.aiWorkflowRunUpdateInput & {
         initialScore?: number | null;
-        status?: string;
         completedAt?: Date | null;
       };
 
@@ -844,7 +843,6 @@ export class AiWorkflowService {
           where: { id: runId },
           select: {
             score: true,
-            status: true,
             initialScore: true,
             completedAt: true,
             workflow: {
@@ -869,24 +867,8 @@ export class AiWorkflowService {
             updateData.initialScore = existingRun.score;
           }
 
-          if (
-            existingRun.status &&
-            existingRun.score !== null &&
-            existingRun.score !== patchData.score
-          ) {
-            const minPassingScore =
-              existingRun.workflow?.scorecard?.minimumPassingScore;
-            if (minPassingScore != null) {
-              const status =
-                patchData.score >= Number(minPassingScore)
-                  ? 'SUCCESS'
-                  : 'FAILURE';
-              updateData.status = status;
-
-              if (existingRun.completedAt == null) {
-                updateData.completedAt = new Date();
-              }
-            }
+          if (existingRun.completedAt == null) {
+            updateData.completedAt = new Date();
           }
         }
       }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -882,7 +882,7 @@ export class AiWorkflowService {
                   ? 'SUCCESS'
                   : 'FAILURE';
               updateData.status = status;
-  
+
               if (existingRun.completedAt == null) {
                 updateData.completedAt = new Date();
               }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -844,6 +844,7 @@ export class AiWorkflowService {
           where: { id: runId },
           select: {
             score: true,
+            status: true,
             initialScore: true,
             completedAt: true,
             workflow: {
@@ -858,6 +859,7 @@ export class AiWorkflowService {
           },
         });
 
+        // update final score and status when manager updates score
         if (existingRun) {
           if (
             existingRun.initialScore === null &&
@@ -867,17 +869,23 @@ export class AiWorkflowService {
             updateData.initialScore = existingRun.score;
           }
 
-          const minPassingScore =
-            existingRun.workflow?.scorecard?.minimumPassingScore;
-          if (minPassingScore != null) {
-            const status =
-              patchData.score >= Number(minPassingScore)
-                ? 'SUCCESS'
-                : 'FAILURE';
-            updateData.status = status;
-
-            if (existingRun.completedAt == null) {
-              updateData.completedAt = new Date();
+          if (
+            existingRun.status &&
+            existingRun.score !== null &&
+            existingRun.score !== patchData.score
+          ) {
+            const minPassingScore =
+              existingRun.workflow?.scorecard?.minimumPassingScore;
+            if (minPassingScore != null) {
+              const status =
+                patchData.score >= Number(minPassingScore)
+                  ? 'SUCCESS'
+                  : 'FAILURE';
+              updateData.status = status;
+  
+              if (existingRun.completedAt == null) {
+                updateData.completedAt = new Date();
+              }
             }
           }
         }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -833,12 +833,31 @@ export class AiWorkflowService {
     }
 
     try {
+      const updateData: Prisma.aiWorkflowRunUpdateInput = { ...patchData };
+
+      if (patchData.score !== undefined) {
+        const existingRun = await this.prisma.aiWorkflowRun.findUnique({
+          where: { id: runId },
+          select: { score: true, initialScore: true },
+        });
+
+        if (existingRun) {
+          if (
+            existingRun.initialScore === null &&
+            existingRun.score !== null &&
+            existingRun.score !== patchData.score
+          ) {
+            updateData.initialScore = existingRun.score;
+          }
+        }
+      }
+
       await this.prisma.aiWorkflowRun.update({
         where: {
           workflowId,
           id: runId,
         },
-        data: { ...patchData },
+        data: updateData,
       });
     } catch (error) {
       if (

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -833,12 +833,29 @@ export class AiWorkflowService {
     }
 
     try {
-      const updateData: Prisma.aiWorkflowRunUpdateInput = { ...patchData };
+      const updateData = { ...patchData } as Prisma.aiWorkflowRunUpdateInput & {
+        initialScore?: number | null;
+        status?: string;
+        completedAt?: Date | null;
+      };
 
       if (patchData.score !== undefined) {
         const existingRun = await this.prisma.aiWorkflowRun.findUnique({
           where: { id: runId },
-          select: { score: true, initialScore: true },
+          select: {
+            score: true,
+            initialScore: true,
+            completedAt: true,
+            workflow: {
+              select: {
+                scorecard: {
+                  select: {
+                    minimumPassingScore: true,
+                  },
+                },
+              },
+            },
+          },
         });
 
         if (existingRun) {
@@ -848,6 +865,20 @@ export class AiWorkflowService {
             existingRun.score !== patchData.score
           ) {
             updateData.initialScore = existingRun.score;
+          }
+
+          const minPassingScore =
+            existingRun.workflow?.scorecard?.minimumPassingScore;
+          if (minPassingScore != null) {
+            const status =
+              patchData.score >= Number(minPassingScore)
+                ? 'SUCCESS'
+                : 'FAILURE';
+            updateData.status = status;
+
+            if (existingRun.completedAt == null) {
+              updateData.completedAt = new Date();
+            }
           }
         }
       }

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -5242,16 +5242,9 @@ export class SubmissionService {
         continue;
       }
 
-      const reviews = Array.isArray(submission.review)
-        ? (submission.review as Array<Record<string, unknown>>)
-        : [];
-
-      // Set the finalScore on each review to the AI decision's totalScore
-      for (const review of reviews) {
-        review.finalScore = decision.totalScore;
-      }
-
       // Also set on the submission itself for convenience
+      (submission as Record<string, unknown>).finalScore =
+        decision.totalScore;
       (submission as Record<string, unknown>).aiDecisionScore =
         decision.totalScore;
       (submission as Record<string, unknown>).aiDecisionStatus =

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -2957,6 +2957,7 @@ export class SubmissionService {
       await this.populateReviewPhaseNames(submissions);
       await this.populateReviewTypeNames(submissions);
       await this.enrichReviewerMetadata(submissions);
+      await this.enrichAiDecisionScores(submissions);
 
       // Count total entities matching the filter for pagination metadata
       let totalCount = await this.prisma.submission.count({
@@ -3101,6 +3102,7 @@ export class SubmissionService {
 
     const data = await this.checkSubmission(id, authUser);
     await this.populateLatestSubmissionFlags([data]);
+    await this.enrichAiDecisionScores([data]);
     await this.stripIsLatestForUnlimitedChallenges([data]);
     return this.buildResponse(data);
   }
@@ -5157,6 +5159,103 @@ export class SubmissionService {
         `[hasPassingSubmissionForReviewScorecard] Failed to check passing submission for challenge ${normalizedChallengeId}, member ${normalizedMemberId}: ${message}`,
       );
       return false;
+    }
+  }
+
+  /**
+   * Enriches submissions with AI decision totalScore as finalScore for AI-only challenges.
+   * For each submission, if an AI review config exists for its challenge and there's
+   * a non-PENDING AI decision, sets the finalScore on the submission's reviews to the
+   * decision's totalScore.
+   */
+  private async enrichAiDecisionScores(
+    submissions: Array<{
+      id: string;
+      challengeId?: string | null;
+      review?: unknown;
+    }>,
+  ): Promise<void> {
+    if (!submissions.length) {
+      return;
+    }
+
+    const challengeIds = Array.from(
+      new Set(
+        submissions
+          .map((s) => s.challengeId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    if (!challengeIds.length) {
+      return;
+    }
+
+    // Find which challenges have AI review configs (AI-only challenges)
+    const aiConfigRows = await this.prisma.$queryRaw<
+      Array<{ challengeId: string }>
+    >(Prisma.sql`
+      SELECT DISTINCT "challengeId"
+      FROM "aiReviewConfig"
+      WHERE "challengeId" IN (${Prisma.join(challengeIds)})
+        AND "mode" = 'AI_ONLY'
+    `);
+
+    const aiOnlyChallengeIds = new Set(aiConfigRows.map((r) => r.challengeId));
+    if (!aiOnlyChallengeIds.size) {
+      return;
+    }
+
+    // Get submissions that belong to AI-only challenges
+    const aiSubmissions = submissions.filter(
+      (s) => s.challengeId && aiOnlyChallengeIds.has(s.challengeId),
+    );
+
+    if (!aiSubmissions.length) {
+      return;
+    }
+
+    const submissionIds = aiSubmissions.map((s) => s.id);
+
+    // Fetch the latest AI decision for each submission
+    const decisionRows = await this.prisma.$queryRaw<
+      Array<{ submissionId: string; totalScore: number | null; status: string }>
+    >(Prisma.sql`
+      SELECT DISTINCT ON ("submissionId")
+        "submissionId",
+        "totalScore",
+        status::text AS "status"
+      FROM "aiReviewDecision"
+      WHERE "submissionId" IN (${Prisma.join(submissionIds)})
+        AND UPPER(status::text) != 'PENDING'
+      ORDER BY "submissionId", "updatedAt" DESC
+    `);
+
+    const decisionBySubmissionId = new Map(
+      decisionRows.map((d) => [d.submissionId, d]),
+    );
+
+    // Enrich submissions with AI decision scores
+    for (const submission of aiSubmissions) {
+      const decision = decisionBySubmissionId.get(submission.id);
+      if (!decision || decision.totalScore === null) {
+        continue;
+      }
+
+      const reviews = Array.isArray(submission.review)
+        ? (submission.review as Array<Record<string, unknown>>)
+        : [];
+
+      // Set the finalScore on each review to the AI decision's totalScore
+      for (const review of reviews) {
+        review.finalScore = decision.totalScore;
+      }
+
+      // Also set on the submission itself for convenience
+      (submission as Record<string, unknown>).aiDecisionScore =
+        decision.totalScore;
+      (submission as Record<string, unknown>).aiDecisionStatus =
+        decision.status;
     }
   }
 

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -5243,8 +5243,7 @@ export class SubmissionService {
       }
 
       // Also set on the submission itself for convenience
-      (submission as Record<string, unknown>).finalScore =
-        decision.totalScore;
+      (submission as Record<string, unknown>).finalScore = decision.totalScore;
       (submission as Record<string, unknown>).aiDecisionScore =
         decision.totalScore;
       (submission as Record<string, unknown>).aiDecisionStatus =

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -5163,10 +5163,10 @@ export class SubmissionService {
   }
 
   /**
-   * Enriches submissions with AI decision totalScore as finalScore for AI-only challenges.
+   * Enriches submissions with the latest (non-PENDING) AI decision totalScore for AI-only challenges.
    * For each submission, if an AI review config exists for its challenge and there's
-   * a non-PENDING AI decision, sets the finalScore on the submission's reviews to the
-   * decision's totalScore.
+   * a non-PENDING AI decision, sets `finalScore`, `aiDecisionScore`, and `aiDecisionStatus`
+   * on the submission object.
    */
   private async enrichAiDecisionScores(
     submissions: Array<{

--- a/src/dto/aiReviewDecision.dto.ts
+++ b/src/dto/aiReviewDecision.dto.ts
@@ -1,6 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsEnum } from 'class-validator';
-import { Transform } from 'class-transformer';
+import {
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsNumber,
+  IsArray,
+  ValidateNested,
+  Min,
+  Max,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 import { AiReviewDecisionEscalationResponseDto } from './aiReviewEscalation.dto';
 
 const trimTransformer = ({ value }: { value: unknown }): string | undefined =>
@@ -116,4 +125,59 @@ export class AiReviewDecisionResponseDto {
     type: [AiReviewDecisionEscalationResponseDto],
   })
   escalations?: AiReviewDecisionEscalationResponseDto[];
+
+  @ApiProperty({
+    description: 'Manager comment left during the Approval phase',
+    required: false,
+    nullable: true,
+  })
+  managerComment: string | null;
+}
+
+export class WorkflowManagerOverrideDto {
+  @ApiProperty({ description: 'Workflow ID to override' })
+  @IsString()
+  workflowId: string;
+
+  @ApiProperty({
+    description: 'Manager score override (0–100)',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  managerScore?: number | null;
+
+  @ApiProperty({
+    description: 'Manager comment for this workflow entry',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  workflowComment?: string | null;
+}
+
+export class PatchAiReviewDecisionDto {
+  @ApiProperty({
+    description: 'Overall manager comment for this decision',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  managerComment?: string | null;
+
+  @ApiProperty({
+    description: 'Per-workflow score/comment overrides',
+    required: false,
+    type: [WorkflowManagerOverrideDto],
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => WorkflowManagerOverrideDto)
+  workflowOverrides?: WorkflowManagerOverrideDto[];
 }

--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -499,7 +499,6 @@ export class WorkflowQueueHandler {
 
     const aiWorkflowRuns = await this.prisma.aiWorkflowRun.findMany({
       where: {
-        status: { in: ['DISPATCHED', 'IN_PROGRESS'] },
         gitRunId: `${event.workflow_job.run_id}`,
       },
       include: {
@@ -509,12 +508,21 @@ export class WorkflowQueueHandler {
 
     if (aiWorkflowRuns.length > 1) {
       this.logger.error(
-        `ERROR! There are more than 1 workflow runs in DISPATCHED status and workflow.gitWorkflowId=${event.workflow_job.name}!`,
+        `ERROR! There are more than 1 workflow runs for gitRunId=${event.workflow_job.run_id} and workflow.gitWorkflowId=${event.workflow_job.name}!`,
       );
       return;
     }
 
     let [aiWorkflowRun]: ((typeof aiWorkflowRuns)[0] | null)[] = aiWorkflowRuns;
+
+    if (
+      aiWorkflowRun &&
+      !['DISPATCHED', 'IN_PROGRESS'].includes(aiWorkflowRun.status)
+    ) {
+      const errorMessage = `Unexpected aiWorkflowRun status '${aiWorkflowRun.status}' for gitRunId=${event.workflow_job.run_id} and workflowJobName=${event.workflow_job.name}`;
+      this.logger.error(errorMessage);
+      return;
+    }
 
     if (
       !aiWorkflowRun &&


### PR DESCRIPTION
This pull request introduces several enhancements and new capabilities to the AI review decision and workflow management system, with a focus on enabling privileged users to override AI review outcomes and improving how AI review scores are surfaced in submissions. The changes span database schema updates, API endpoints, DTOs, and service logic.

**Key changes include:**

### AI Review Decision Manager Override & Comments

- Added support for managers (Admins and Copilots) to override AI review decisions via a new `PATCH /ai-review-decision/:id` endpoint. This allows setting a manager comment and/or per-workflow score overrides, recalculating the total score and updating status to `HUMAN_OVERRIDE`. [[1]](diffhunk://#diff-d9a927bf7c05b79b32388be12698bfaaf8ca340509730b08509791695bebbebdR127-R159) [[2]](diffhunk://#diff-50b682536fa33a9afdbc225a06c6d9fadcfdd4958def670436dcd0259cb01861R332-R501) [[3]](diffhunk://#diff-054a1dd8af0fb999639f900d1a0d80adcb3b80325b6dacff66398f843e0a02f3R128-R182)
- The `aiReviewDecision` model and database table now include a `managerComment` field to store manager-provided comments. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR889-R890) [[2]](diffhunk://#diff-af6c3af01dc434291d2c0e8aa4befa33df926170f27a477230527628871ae192R1-R2)
- DTOs updated to support the new override payload, including per-workflow score and comment overrides.

### Workflow Run Score Tracking

- Introduced an `initialScore` field to the `aiWorkflowRun` model and database table, allowing the system to track the original AI-generated score when a manager override occurs. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR735) [[2]](diffhunk://#diff-346d7cb6ecdd85c45e5d091fdecc769ae4d1815fa988da4e3e1707eb6cfc3382R1-R2)
- Service logic updated to set `initialScore` and adjust workflow run status and completion timestamp when a manager overrides the score. [[1]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11R836-R899) [[2]](diffhunk://#diff-50b682536fa33a9afdbc225a06c6d9fadcfdd4958def670436dcd0259cb01861R332-R501)

### Submission Enrichment with AI Decision Scores

- Submissions for AI-only challenges are now enriched with the latest (non-pending) AI decision's total score, making it available as `finalScore`, `aiDecisionScore`, and `aiDecisionStatus` in the submission object. [[1]](diffhunk://#diff-a9958a13ec7920ead791281beac4d5e98e31f5150251fee2e161b9abd4611506R2960) [[2]](diffhunk://#diff-a9958a13ec7920ead791281beac4d5e98e31f5150251fee2e161b9abd4611506R3105) [[3]](diffhunk://#diff-a9958a13ec7920ead791281beac4d5e98e31f5150251fee2e161b9abd4611506R5165-R5253)

### Access Control and API Improvements

- Expanded allowed roles for creating and updating AI review configs to include `ProjectManager` in addition to existing roles. [[1]](diffhunk://#diff-e1c9ea97fd7a5ada071f0392a7da73272a55ce51bbe4d00142ed1ddd3ce035b9L39-R44) [[2]](diffhunk://#diff-e1c9ea97fd7a5ada071f0392a7da73272a55ce51bbe4d00142ed1ddd3ce035b9L114-R124)

---

**Most important changes:**

#### AI Review Decision Overrides & Comments
- Added a new PATCH endpoint to allow Admins and Copilots to override AI review decisions, set manager comments, and override per-workflow scores, with recalculation of the total score and status update to `HUMAN_OVERRIDE`. [[1]](diffhunk://#diff-d9a927bf7c05b79b32388be12698bfaaf8ca340509730b08509791695bebbebdR127-R159) [[2]](diffhunk://#diff-50b682536fa33a9afdbc225a06c6d9fadcfdd4958def670436dcd0259cb01861R332-R501) [[3]](diffhunk://#diff-054a1dd8af0fb999639f900d1a0d80adcb3b80325b6dacff66398f843e0a02f3R128-R182)
- Added a `managerComment` field to both the database and API response for `aiReviewDecision`. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR889-R890) [[2]](diffhunk://#diff-af6c3af01dc434291d2c0e8aa4befa33df926170f27a477230527628871ae192R1-R2) [[3]](diffhunk://#diff-50b682536fa33a9afdbc225a06c6d9fadcfdd4958def670436dcd0259cb01861R61) [[4]](diffhunk://#diff-50b682536fa33a9afdbc225a06c6d9fadcfdd4958def670436dcd0259cb01861R169)

#### Workflow Run Enhancements
- Added an `initialScore` field to `aiWorkflowRun` to preserve the original AI score when manager overrides occur, with logic to update this field and workflow run status appropriately. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR735) [[2]](diffhunk://#diff-346d7cb6ecdd85c45e5d091fdecc769ae4d1815fa988da4e3e1707eb6cfc3382R1-R2) [[3]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11R836-R899)

#### Submission Data Enrichment
- Submissions for AI-only challenges are now enriched with the latest AI decision score and status, making this information directly available in submission responses. [[1]](diffhunk://#diff-a9958a13ec7920ead791281beac4d5e98e31f5150251fee2e161b9abd4611506R2960) [[2]](diffhunk://#diff-a9958a13ec7920ead791281beac4d5e98e31f5150251fee2e161b9abd4611506R3105) [[3]](diffhunk://#diff-a9958a13ec7920ead791281beac4d5e98e31f5150251fee2e161b9abd4611506R5165-R5253)

#### API Role Expansion
- Expanded role permissions for creating and updating AI review configs to include `ProjectManager`. [[1]](diffhunk://#diff-e1c9ea97fd7a5ada071f0392a7da73272a55ce51bbe4d00142ed1ddd3ce035b9L39-R44) [[2]](diffhunk://#diff-e1c9ea97fd7a5ada071f0392a7da73272a55ce51bbe4d00142ed1ddd3ce035b9L114-R124)