### PR TITLE
PM-5226 - hide score for submitters

### DIFF
--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -726,6 +726,7 @@ describe('SubmissionService', () => {
         findMany: jest.Mock;
         count: jest.Mock;
         findFirst: jest.Mock;
+        findUnique: jest.Mock;
       };
       reviewType: {
         findMany: jest.Mock;
@@ -754,6 +755,7 @@ describe('SubmissionService', () => {
           findMany: jest.fn(),
           count: jest.fn(),
           findFirst: jest.fn(),
+          findUnique: jest.fn(),
         },
         reviewType: {
           findMany: jest.fn().mockResolvedValue([]),
@@ -1054,6 +1056,186 @@ describe('SubmissionService', () => {
       expect(challengeApiServiceMock.getChallengeDetail).toHaveBeenCalledWith(
         'challenge-1',
       );
+    });
+
+    it('omits review data for unrelated users before completion', async () => {
+      const submissions = [
+        {
+          id: 'submission-other',
+          challengeId: 'challenge-1',
+          memberId: 'user-2',
+          submittedDate: new Date('2025-01-01T12:00:00Z'),
+          createdAt: new Date('2025-01-01T12:00:00Z'),
+          updatedAt: new Date('2025-01-01T12:00:00Z'),
+          type: SubmissionType.CONTEST_SUBMISSION,
+          status: SubmissionStatus.ACTIVE,
+          review: [{ id: 'review-other' }],
+          reviewSummation: [],
+          legacyChallengeId: null,
+          prizeId: null,
+        },
+      ];
+
+      resourceApiServiceListMock.getMemberResourcesRoles.mockResolvedValue([]);
+
+      prismaMock.submission.findMany.mockResolvedValue(
+        submissions.map((entry) => ({ ...entry })),
+      );
+      prismaMock.submission.count.mockResolvedValue(submissions.length);
+      prismaMock.submission.findFirst.mockResolvedValue({
+        id: 'submission-other',
+      });
+
+      const result = await listService.listSubmission(
+        {
+          userId: 'user-3',
+          isMachine: false,
+          roles: [],
+        } as any,
+        { challengeId: 'challenge-1' } as any,
+        { page: 1, perPage: 50 } as any,
+      );
+
+      const other = result.data[0];
+      expect(other).not.toHaveProperty('review');
+      expect(other.reviewSummation).toEqual([]);
+      expect(
+        resourceApiServiceListMock.getMemberResourcesRoles,
+      ).toHaveBeenCalledWith('challenge-1', 'user-3');
+      expect(challengeApiServiceMock.getChallengeDetail).toHaveBeenCalledWith(
+        'challenge-1',
+      );
+    });
+
+    it('strips review details for unauthorized active challenge getSubmission requests', async () => {
+      const submission = {
+        id: 'submission-unauthorized',
+        challengeId: 'challenge-1',
+        memberId: 'user-2',
+        submittedDate: new Date('2025-01-01T12:00:00Z'),
+        createdAt: new Date('2025-01-01T12:00:00Z'),
+        updatedAt: new Date('2025-01-01T12:00:00Z'),
+        type: SubmissionType.CONTEST_SUBMISSION,
+        status: SubmissionStatus.ACTIVE,
+        review: [
+          {
+            id: 'review-1',
+            initialScore: 50,
+            finalScore: 55,
+            reviewItems: [],
+          },
+        ],
+        reviewSummation: [{ id: 'summation-1', metadata: { foo: 'bar' } }],
+        legacyChallengeId: null,
+        prizeId: null,
+      };
+
+      prismaMock.submission.findUnique.mockResolvedValue(submission);
+      resourceApiServiceListMock.getMemberResourcesRoles.mockResolvedValue([]);
+      challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+        id: 'challenge-1',
+        status: ChallengeStatus.ACTIVE,
+        type: 'Challenge',
+        legacy: {},
+        phases: [],
+      });
+
+      const result = await listService.getSubmission(
+        {
+          userId: 'user-3',
+          isMachine: false,
+          roles: [],
+        } as any,
+        'submission-unauthorized',
+      );
+
+      expect(result.review).toBeUndefined();
+      expect(result.reviewSummation).toBeDefined();
+      expect(challengeApiServiceMock.getChallengeDetail).toHaveBeenCalledWith(
+        'challenge-1',
+      );
+    });
+
+    it('allows submitters to see review scores for their own submission while the challenge is active', async () => {
+      const now = new Date('2025-01-02T12:00:00Z');
+      const submissions = [
+        {
+          id: 'submission-own',
+          challengeId: 'challenge-1',
+          memberId: 'user-1',
+          submittedDate: now,
+          createdAt: now,
+          updatedAt: now,
+          type: SubmissionType.CONTEST_SUBMISSION,
+          status: SubmissionStatus.ACTIVE,
+          review: [
+            {
+              id: 'review-own',
+              phaseId: 'phase-review',
+              initialScore: 90,
+              finalScore: 95,
+              reviewItems: [
+                {
+                  id: 'item-1',
+                  scorecardQuestionId: 'q1',
+                  initialAnswer: 'YES',
+                  finalAnswer: 'YES',
+                  reviewItemComments: [],
+                },
+              ],
+            },
+          ],
+          reviewSummation: [],
+          legacyChallengeId: null,
+          prizeId: null,
+        },
+      ];
+
+      resourceApiServiceListMock.getMemberResourcesRoles.mockResolvedValue([
+        {
+          roleName: 'Submitter',
+          roleId: CommonConfig.roles.submitterRoleId,
+        },
+      ]);
+      challengeApiServiceMock.getChallengeDetail.mockResolvedValueOnce({
+        id: 'challenge-1',
+        status: ChallengeStatus.ACTIVE,
+        type: 'Challenge',
+        legacy: {},
+        phases: [
+          {
+            id: 'phase-review',
+            phaseId: 'phase-review',
+            name: 'Review',
+            isOpen: false,
+            actualEndTime: new Date('2025-01-01T12:00:00Z').toISOString(),
+          },
+        ],
+      });
+
+      prismaMock.submission.findMany.mockResolvedValue(
+        submissions.map((entry) => ({ ...entry })),
+      );
+      prismaMock.submission.count.mockResolvedValue(submissions.length);
+      prismaMock.submission.findFirst.mockResolvedValue({
+        id: 'submission-own',
+      });
+
+      const result = await listService.listSubmission(
+        {
+          userId: 'user-1',
+          isMachine: false,
+          roles: [UserRole.User],
+        } as any,
+        { challengeId: 'challenge-1' } as any,
+        { page: 1, perPage: 50 } as any,
+      );
+
+      const submissionResult = result.data[0];
+      expect(submissionResult.review).toHaveLength(1);
+      expect(submissionResult.review?.[0]?.initialScore).toBe(90);
+      expect(submissionResult.review?.[0]?.finalScore).toBe(95);
+      expect(submissionResult.review?.[0]?.reviewItems).toHaveLength(1);
     });
 
     it('retains review data for other submissions once the challenge completes', async () => {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -3103,6 +3103,23 @@ export class SubmissionService {
     const data = await this.checkSubmission(id, authUser);
     await this.populateLatestSubmissionFlags([data]);
     await this.enrichAiDecisionScores([data]);
+
+    const reviewVisibilityContext = await this.applyReviewVisibilityFilters(
+      authUser,
+      [data],
+    );
+    this.stripSubmitterMemberIds(authUser, [data], reviewVisibilityContext);
+    this.stripSubmitterSubmissionDetails(
+      authUser,
+      [data],
+      reviewVisibilityContext,
+    );
+    this.sanitizeMemberVisibleReviewSummationMetadata(
+      authUser,
+      [data],
+      reviewVisibilityContext,
+    );
+
     await this.stripIsLatestForUnlimitedChallenges([data]);
     return this.buildResponse(data);
   }


### PR DESCRIPTION
This pull request adds and tests new logic to control the visibility of review data in submissions, ensuring that sensitive review information is only shown to authorized users under the correct conditions. The changes include both implementation updates and new tests to verify this behavior.

**Review data visibility controls:**

* Added logic in `SubmissionService.getSubmission` to filter or strip review and review summation data from submissions based on the requesting user's authorization and the challenge status. This ensures that only authorized users (such as the submitter) can view review details while a challenge is active, and that unrelated users cannot access this information.

**Unit tests for review data access:**

* Added tests to verify that review data is omitted for unrelated users before challenge completion, ensuring privacy of submission reviews.
* Added tests to confirm that unauthorized users do not receive review details when requesting active challenge submissions.
* Added tests to check that submitters can see review scores for their own submissions during an active challenge.

**Test mock updates:**

* Updated the Prisma mock in `submission.service.spec.ts` to include the `findUnique` method, supporting the new test scenarios. [[1]](diffhunk://#diff-04e6d7e55ff02dab13f06f48e72af830f9adf47313481549c971b90b3ef9a8bcR729) [[2]](diffhunk://#diff-04e6d7e55ff02dab13f06f48e72af830f9adf47313481549c971b90b3ef9a8bcR758)