### PR TITLE
PM-5226 hide score for submitters

### DIFF
--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -986,7 +986,7 @@ describe('SubmissionService', () => {
       expect(result.data[1]).not.toHaveProperty('isLatest');
     });
 
-    it('omits review data for non-owned submissions before completion', async () => {
+    it('omits review data and submission id for other submitters while challenge is active', async () => {
       const submissions = [
         {
           id: 'submission-own',
@@ -1043,13 +1043,13 @@ describe('SubmissionService', () => {
         { page: 1, perPage: 50 } as any,
       );
 
-      const own = result.data.find((entry) => entry.id === 'submission-own');
-      const other = result.data.find(
-        (entry) => entry.id === 'submission-other',
-      );
+      const own = result.data.find((entry) => entry.memberId === 'user-1');
+      const other = result.data.find((entry) => entry.memberId === 'user-2');
 
       expect(own?.review).toBeDefined();
+      expect(other).toBeDefined();
       expect(other).not.toHaveProperty('review');
+      expect(other).not.toHaveProperty('id');
       expect(
         resourceApiServiceListMock.getMemberResourcesRoles,
       ).toHaveBeenCalledWith('challenge-1', 'user-1');
@@ -1374,11 +1374,11 @@ describe('SubmissionService', () => {
         { page: 1, perPage: 50 } as any,
       );
 
-      const other = result.data.find(
-        (entry) => entry.id === 'submission-other',
-      );
+      const other = result.data.find((entry) => entry.memberId === 'user-2');
 
+      expect(other).toBeDefined();
       expect(other?.review).toBeDefined();
+      expect(other).not.toHaveProperty('id');
     });
 
     it('masks other reviewers scores while preserving reviewer metadata on active challenges', async () => {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -3572,7 +3572,8 @@ export class SubmissionService {
         ? String(authUser.userId).trim()
         : '';
 
-    const isPrivilegedRequester = authUser && (authUser.isMachine || isAdmin(authUser));
+    const isPrivilegedRequester =
+      authUser && (authUser.isMachine || isAdmin(authUser));
     if (!isPrivilegedRequester && !requesterUserId) {
       for (const submission of submissions) {
         if (Object.prototype.hasOwnProperty.call(submission, 'review')) {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -4634,6 +4634,7 @@ export class SubmissionService {
         continue;
       }
 
+      delete (submission as any).id;
       (submission as any).memberId = null;
       if (Object.prototype.hasOwnProperty.call(submission, 'submitterHandle')) {
         delete (submission as any).submitterHandle;
@@ -4738,6 +4739,7 @@ export class SubmissionService {
         }
       }
 
+      delete (submission as any).id;
       if (Object.prototype.hasOwnProperty.call(submission, 'reviewSummation')) {
         delete (submission as any).reviewSummation;
       }

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -3550,7 +3550,7 @@ export class SubmissionService {
   }
 
   private async applyReviewVisibilityFilters(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<{
       challengeId?: string | null;
       memberId?: string | null;
@@ -3572,7 +3572,7 @@ export class SubmissionService {
         ? String(authUser.userId).trim()
         : '';
 
-    const isPrivilegedRequester = authUser?.isMachine || isAdmin(authUser);
+    const isPrivilegedRequester = authUser && (authUser.isMachine || isAdmin(authUser));
     if (!isPrivilegedRequester && !requesterUserId) {
       for (const submission of submissions) {
         if (Object.prototype.hasOwnProperty.call(submission, 'review')) {
@@ -4557,7 +4557,7 @@ export class SubmissionService {
   }
 
   private stripSubmitterMemberIds(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<
       { challengeId?: string | null; memberId?: string | null } & Record<
         string,
@@ -4569,7 +4569,7 @@ export class SubmissionService {
     if (!submissions.length) {
       return;
     }
-    if (authUser?.isMachine || isAdmin(authUser)) {
+    if (authUser && (authUser.isMachine || isAdmin(authUser))) {
       return;
     }
 
@@ -4648,7 +4648,7 @@ export class SubmissionService {
   }
 
   private stripSubmitterSubmissionDetails(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<
       {
         challengeId?: string | null;
@@ -4663,7 +4663,7 @@ export class SubmissionService {
     if (!submissions.length) {
       return;
     }
-    if (authUser?.isMachine || isAdmin(authUser)) {
+    if (authUser && (authUser.isMachine || isAdmin(authUser))) {
       return;
     }
 
@@ -4758,7 +4758,7 @@ export class SubmissionService {
    * Used by `listSubmission` so competitors can see their own test progress without per-seed scores.
    */
   private sanitizeMemberVisibleReviewSummationMetadata(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<
       {
         challengeId?: string | null;
@@ -4770,7 +4770,7 @@ export class SubmissionService {
     if (!submissions.length) {
       return;
     }
-    if (authUser?.isMachine || isAdmin(authUser)) {
+    if (authUser && (authUser.isMachine || isAdmin(authUser))) {
       return;
     }
 


### PR DESCRIPTION
This pull request enhances the privacy of submission data by ensuring that non-privileged users cannot access sensitive information such as submission IDs and reviewer data for submissions they do not own, particularly while a challenge is still active. It also improves the robustness of the code by handling cases where the authenticated user may be undefined. 