### PR TITLE
Allow to edit scores

### DIFF
--- a/prisma/migrations/20260530120000_add_manager_comment_to_ai_review_decision/migration.sql
+++ b/prisma/migrations/20260530120000_add_manager_comment_to_ai_review_decision/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "aiReviewDecision" ADD COLUMN "managerComment" TEXT;

--- a/prisma/migrations/20260608085219_save_original_score_for_ai_workflow_run_item/migration.sql
+++ b/prisma/migrations/20260608085219_save_original_score_for_ai_workflow_run_item/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "aiWorkflowRunItem" ADD COLUMN     "originalQuestionScore" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -754,6 +754,7 @@ model aiWorkflowRunItem {
   scorecardQuestionId String   @db.VarChar(14)
   content             String   @db.Text
   questionScore       Float?   @db.DoublePrecision
+  originalQuestionScore Float? @db.DoublePrecision
   createdAt           DateTime @db.Timestamp(3)
   createdBy           String?  @db.Text
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -887,8 +887,6 @@ model aiReviewDecision {
   isFinal          Boolean  @default(false)
   finalizedAt      DateTime?
 
-  managerComment   String?  @db.Text
-
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 

--- a/src/api/ai-review-decision/ai-review-decision.controller.ts
+++ b/src/api/ai-review-decision/ai-review-decision.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Controller,
-  Get,
-  Param,
-  Query,
-  Patch,
-  Body,
-  ValidationPipe,
-} from '@nestjs/common';
+import { Controller, Get, Param, Query, ValidationPipe } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiTags,
@@ -14,14 +6,12 @@ import {
   ApiResponse,
   ApiParam,
   ApiQuery,
-  ApiBody,
 } from '@nestjs/swagger';
 import { AiReviewDecisionService } from './ai-review-decision.service';
 import {
   ListAiReviewDecisionQueryDto,
   AiReviewDecisionResponseDto,
   AiReviewDecisionStatus,
-  PatchAiReviewDecisionDto,
 } from '../../dto/aiReviewDecision.dto';
 import { Scopes } from 'src/shared/decorators/scopes.decorator';
 import { User } from 'src/shared/decorators/user.decorator';
@@ -123,38 +113,5 @@ export class AiReviewDecisionController {
   @ApiResponse({ status: 404, description: 'AI review decision not found.' })
   async getById(@Param('id') id: string, @User() authUser: JwtUser) {
     return this.aiReviewDecisionService.getById(id, authUser);
-  }
-
-  @Patch(':id')
-  @Roles(UserRole.Admin, UserRole.Copilot)
-  @Scopes(Scope.ReadAiReviewDecision)
-  @ApiOperation({
-    summary: 'Update an AI review decision (manager override)',
-    description:
-      'Roles: Admin, Copilot. Allows setting a manager comment and/or per-workflow score overrides. When workflow overrides are provided the total score is recalculated and the status is set to HUMAN_OVERRIDE.',
-  })
-  @ApiParam({
-    name: 'id',
-    description: 'The ID of the AI review decision',
-    example: '229c5PnhSKqsSu',
-  })
-  @ApiBody({ type: PatchAiReviewDecisionDto })
-  @ApiResponse({
-    status: 200,
-    description: 'Updated AI review decision.',
-    type: AiReviewDecisionResponseDto,
-  })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden. Only Admins and Copilots may update decisions.',
-  })
-  @ApiResponse({ status: 404, description: 'AI review decision not found.' })
-  async patch(
-    @Param('id') id: string,
-    @Body(new ValidationPipe({ whitelist: true, transform: true }))
-    dto: PatchAiReviewDecisionDto,
-    @User() authUser: JwtUser,
-  ) {
-    return this.aiReviewDecisionService.patch(id, dto, authUser);
   }
 }

--- a/src/api/ai-review-decision/ai-review-decision.service.ts
+++ b/src/api/ai-review-decision/ai-review-decision.service.ts
@@ -12,7 +12,6 @@ import {
   ListAiReviewDecisionQueryDto,
   AiReviewDecisionResponseDto,
   AiReviewDecisionStatus,
-  PatchAiReviewDecisionDto,
 } from '../../dto/aiReviewDecision.dto';
 import {
   AiReviewDecisionEscalationResponseDto,
@@ -21,7 +20,6 @@ import {
 import { Prisma } from '@prisma/client';
 import { ChallengeApiService } from 'src/shared/modules/global/challenge.service';
 import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
-import { UserRole } from 'src/shared/enums/userRole.enum';
 
 const DECISION_INCLUDE = {
   config: {
@@ -58,7 +56,6 @@ type AiReviewDecisionRecord = {
   breakdown: Prisma.JsonValue | null;
   isFinal: boolean;
   finalizedAt: Date | null;
-  managerComment: string | null;
   createdAt: Date;
   updatedAt: Date;
   config?: { id: string; challengeId: string; version: number };
@@ -166,7 +163,6 @@ export class AiReviewDecisionService {
       breakdown: row.breakdown as Record<string, unknown> | null,
       isFinal: row.isFinal,
       finalizedAt: row.finalizedAt,
-      managerComment: row.managerComment ?? null,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
       config: row.config as Record<string, unknown>,
@@ -328,181 +324,5 @@ export class AiReviewDecisionService {
     }
 
     return this.mapToResponse(decision);
-  }
-
-  async patch(
-    id: string,
-    dto: PatchAiReviewDecisionDto,
-    authUser: JwtUser,
-  ): Promise<AiReviewDecisionResponseDto> {
-    // Only Admin or Copilot role may update AI review decisions
-    const isPrivileged =
-      authUser.isMachine ||
-      isAdmin(authUser) ||
-      authUser.roles?.includes(UserRole.Copilot);
-    if (!isPrivileged) {
-      throw new ForbiddenException(
-        'Only Admins and Copilots may update AI review decisions.',
-      );
-    }
-
-    const decision = await this.prisma.aiReviewDecision.findUnique({
-      where: { id },
-      include: DECISION_INCLUDE,
-    });
-    if (!decision) {
-      throw new NotFoundException(
-        `AI review decision with id ${id} not found.`,
-      );
-    }
-
-    // Build update payload
-    const updateData: Prisma.aiReviewDecisionUpdateInput = {};
-    const runUpdates: Array<{
-      runId: string;
-      managerScore: number;
-      runStatus: 'SUCCESS' | 'FAILURE';
-    }> = [];
-
-    if (dto.managerComment !== undefined) {
-      updateData.managerComment = dto.managerComment;
-    }
-
-    if (dto.workflowOverrides?.length) {
-      // Merge manager overrides into breakdown JSON
-      const currentBreakdown =
-        (decision.breakdown as Record<string, unknown> | null) ?? {};
-      const workflows = Array.isArray(
-        (currentBreakdown as { workflows?: unknown }).workflows,
-      )
-        ? ([
-            ...(currentBreakdown as { workflows: unknown[] }).workflows,
-          ] as Array<Record<string, unknown>>)
-        : [];
-
-      if (!workflows.length) {
-        throw new BadRequestException(
-          'Cannot apply workflow overrides: decision breakdown is missing workflow entries.',
-        );
-      }
-
-      const determineRunStatus = (
-        workflow: Record<string, unknown>,
-        score: number,
-      ) => {
-        const minPassing =
-          workflow['minimumPassingScore'] != null
-            ? Number(workflow['minimumPassingScore'])
-            : 0;
-        return score >= minPassing ? 'SUCCESS' : 'FAILURE';
-      };
-
-      for (const override of dto.workflowOverrides) {
-        const idx = workflows.findIndex(
-          (w) => w['workflowId'] === override.workflowId,
-        );
-        if (idx === -1) continue;
-        if (override.managerScore !== undefined) {
-          workflows[idx] = {
-            ...workflows[idx],
-            managerScore: override.managerScore,
-          };
-
-          let runId: string | null = null;
-          if (typeof workflows[idx]['runId'] === 'string') {
-            runId = workflows[idx]['runId'];
-          }
-          if (runId && override.managerScore !== null) {
-            runUpdates.push({
-              runId,
-              managerScore: override.managerScore,
-              runStatus: determineRunStatus(
-                workflows[idx],
-                override.managerScore,
-              ),
-            });
-          }
-        }
-        if (override.workflowComment !== undefined) {
-          workflows[idx] = {
-            ...workflows[idx],
-            workflowComment: override.workflowComment,
-          };
-        }
-      }
-
-      updateData.breakdown = {
-        ...currentBreakdown,
-        workflows: workflows as unknown as Prisma.InputJsonObject,
-      };
-
-      // Recalculate totalScore from workflows using managerScore ?? runScore
-      const newTotal = workflows.reduce((sum, w) => {
-        const score =
-          w['managerScore'] != null
-            ? Number(w['managerScore'])
-            : w['runScore'] != null
-              ? Number(w['runScore'])
-              : 0;
-        const weight =
-          w['weightPercent'] != null ? Number(w['weightPercent']) : 0;
-        return sum + (score * weight) / 100;
-      }, 0);
-
-      updateData.totalScore = new Prisma.Decimal(newTotal.toFixed(2));
-      updateData.status = 'HUMAN_OVERRIDE';
-    }
-
-    const updated = await this.prisma.$transaction(async (tx) => {
-      const updatedDecision = await tx.aiReviewDecision.update({
-        where: { id },
-        data: updateData,
-        include: DECISION_INCLUDE,
-      });
-
-      for (const runUpdate of runUpdates) {
-        const existingRun = await tx.aiWorkflowRun.findUnique({
-          where: { id: runUpdate.runId },
-          select: { score: true, initialScore: true, completedAt: true },
-        });
-
-        if (!existingRun) {
-          continue;
-        }
-
-        const aiWorkflowRunUpdate: Prisma.aiWorkflowRunUpdateInput & {
-          initialScore?: number | null;
-          status?: string;
-          completedAt?: Date | null;
-        } = {
-          score: runUpdate.managerScore,
-          status: runUpdate.runStatus,
-        };
-
-        if (
-          existingRun.initialScore === null &&
-          existingRun.score !== null &&
-          existingRun.score !== runUpdate.managerScore
-        ) {
-          aiWorkflowRunUpdate.initialScore = existingRun.score;
-        }
-
-        if (
-          ['SUCCESS', 'FAILURE'].includes(runUpdate.runStatus) &&
-          existingRun.completedAt == null
-        ) {
-          aiWorkflowRunUpdate.completedAt = new Date();
-        }
-
-        await tx.aiWorkflowRun.update({
-          where: { id: runUpdate.runId },
-          data: aiWorkflowRunUpdate,
-        });
-      }
-
-      return updatedDecision;
-    });
-
-    return this.mapToResponse(updated as AiReviewDecisionRecord);
   }
 }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -23,6 +23,8 @@ import {
   ChallengeData,
 } from 'src/shared/modules/global/challenge.service';
 import { ResourceApiService } from 'src/shared/modules/global/resource.service';
+import { AiReviewerDecisionMakerService } from 'src/shared/modules/global/ai-reviewer-decision-maker.service';
+import { computeScorecardTotal } from 'src/shared/modules/global/scorecard-score.util';
 import { UserRole } from 'src/shared/enums/userRole.enum';
 import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
 import { LoggerService } from 'src/shared/modules/global/logger.service';
@@ -41,6 +43,7 @@ export class AiWorkflowService {
     private readonly memberPrisma: MemberPrismaService,
     private readonly challengeApiService: ChallengeApiService,
     private readonly resourceApiService: ResourceApiService,
+    private readonly aiReviewerDecisionMaker: AiReviewerDecisionMakerService,
     private readonly giteaService: GiteaService,
     private readonly workflowQueueHandler: WorkflowQueueHandler,
     private readonly challengePrisma: ChallengePrismaService,
@@ -1124,7 +1127,7 @@ export class AiWorkflowService {
 
     if (!user.isMachine) {
       const keys = Object.keys(patchData);
-      const prohibitedKeys = ['content', 'questionScore'];
+      const prohibitedKeys = ['content'];
       if (keys.some((key) => prohibitedKeys.includes(key))) {
         throw new BadRequestException(
           `Users cannot update one of these properties - ${prohibitedKeys.join(',')}`,
@@ -1168,20 +1171,96 @@ export class AiWorkflowService {
       delete patchData.upVote;
     }
 
-    // Update other properties only allowed for machine users
+    const isPrivilegedRunItemScoreUpdater =
+      !user.isMachine &&
+      Boolean(
+        user.roles?.some(
+          (role) =>
+            role === UserRole.Admin ||
+            role === UserRole.Copilot ||
+            role === UserRole.ProjectManager,
+        ),
+      );
+
     const updateData: any = {};
-    if (user.isMachine) {
-      if (patchData.content) {
-        updateData.content = patchData.content;
-      }
-      if (patchData.questionScore) {
-        updateData.questionScore = patchData.questionScore;
-      }
+    if (user.isMachine && patchData.content) {
+      updateData.content = patchData.content;
     }
 
-    // If there are no other fields to update
-    // just return the run item
-    if (Object.keys(updateData).length === 0) {
+    const scoreUpdateRequested = patchData.questionScore !== undefined;
+    const commentText =
+      typeof patchData.comment === 'string'
+        ? patchData.comment.trim()
+        : undefined;
+
+    let runScore: number | null = null;
+
+    if (scoreUpdateRequested) {
+      if (user.isMachine) {
+        updateData.questionScore = patchData.questionScore;
+      } else if (isPrivilegedRunItemScoreUpdater) {
+        if (!commentText) {
+          throw new BadRequestException(
+            'A comment is required when updating question score.',
+          );
+        }
+
+        if (!run.submissionId) {
+          throw new ForbiddenException(
+            'Unable to validate approval phase for this run.',
+          );
+        }
+
+        const submission = await this.prisma.submission.findUnique({
+          where: { id: run.submissionId },
+          select: { challengeId: true },
+        });
+
+        if (!submission?.challengeId) {
+          throw new ForbiddenException(
+            'Unable to validate approval phase for this run.',
+          );
+        }
+
+        const approvalOpen = await this.challengeApiService.isPhaseOpen(
+          submission.challengeId,
+          'Approval',
+        );
+
+        if (!approvalOpen) {
+          throw new ForbiddenException(
+            'Question score edits are only allowed during the approval phase.',
+          );
+        }
+
+        updateData.questionScore = patchData.questionScore;
+        if (
+          runItem.questionScore !== undefined &&
+          runItem.questionScore !== null
+        ) {
+          updateData.originalQuestionScore = runItem.questionScore;
+        }
+      } else {
+        throw new ForbiddenException(
+          'Only machine users or privileged roles may update question score.',
+        );
+      }
+
+      runScore = await this.computeRunScoreForRunItem(
+        workflowId,
+        runId,
+        runItem.scorecardQuestionId,
+        patchData.questionScore as number,
+      );
+    }
+
+    if (commentText && !scoreUpdateRequested) {
+      throw new BadRequestException(
+        'Comment can only be created when updating the question score.',
+      );
+    }
+
+    if (Object.keys(updateData).length === 0 && !commentText) {
       return this.prisma.aiWorkflowRunItem.findUnique({
         where: { id: itemId },
         include: {
@@ -1191,13 +1270,122 @@ export class AiWorkflowService {
       });
     }
 
-    return this.prisma.aiWorkflowRunItem.update({
+    const itemUpdate = this.prisma.aiWorkflowRunItem.update({
       where: { id: itemId },
+      data: updateData,
+    });
+
+    const runUpdate =
+      scoreUpdateRequested && runScore !== null
+        ? this.prisma.aiWorkflowRun.update({
+            where: { id: runId },
+            data: { score: runScore },
+          })
+        : null;
+
+    let updatedItem;
+
+    if (commentText) {
+      if (!user.userId) {
+        throw new BadRequestException('User id is not available');
+      }
+
+      const transactionItems: any = [
+        itemUpdate,
+        this.prisma.aiWorkflowRunItemComment.create({
+          data: {
+            workflowRunItemId: itemId,
+            content: commentText,
+            userId: user.userId.toString(),
+          },
+        }),
+      ];
+
+      if (runUpdate) {
+        transactionItems.push(runUpdate);
+      }
+
+      const [item] = await this.prisma.$transaction(transactionItems);
+      updatedItem = item;
+    } else if (runUpdate) {
+      const [item] = await this.prisma.$transaction([itemUpdate, runUpdate]);
+      updatedItem = item;
+    } else {
+      updatedItem = await itemUpdate;
+    }
+
+    if (scoreUpdateRequested && run.submissionId) {
+      await this.aiReviewerDecisionMaker.evaluateSubmission(run.submissionId);
+    }
+
+    return this.prisma.aiWorkflowRunItem.findUnique({
+      where: { id: updatedItem.id },
       include: {
         comments: true,
         votes: true,
       },
-      data: updateData,
     });
+  }
+
+  private async computeRunScoreForRunItem(
+    workflowId: string,
+    runId: string,
+    questionId: string,
+    questionScore: number,
+  ): Promise<number | null> {
+    const workflowWithScorecard = await this.prisma.aiWorkflow.findUnique({
+      where: { id: workflowId },
+      select: {
+        scorecard: {
+          select: {
+            scorecardGroups: {
+              select: {
+                weight: true,
+                sections: {
+                  select: {
+                    weight: true,
+                    questions: {
+                      select: {
+                        id: true,
+                        type: true,
+                        scaleMin: true,
+                        scaleMax: true,
+                        weight: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!workflowWithScorecard?.scorecard) {
+      return null;
+    }
+
+    const items = await this.prisma.aiWorkflowRunItem.findMany({
+      where: { workflowRunId: runId },
+      select: {
+        scorecardQuestionId: true,
+        questionScore: true,
+      },
+    });
+
+    const answers = new Map(
+      items.map((item) => [
+        item.scorecardQuestionId,
+        item.scorecardQuestionId === questionId
+          ? questionScore
+          : item.questionScore,
+      ]),
+    );
+
+    const scorecard = workflowWithScorecard.scorecard;
+    const totalScore = computeScorecardTotal(scorecard, answers);
+
+    return Math.round((totalScore + Number.EPSILON) * 100) / 100;
   }
 }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -1281,7 +1281,14 @@ export class AiWorkflowService {
       scoreUpdateRequested && runScore !== null
         ? this.prisma.aiWorkflowRun.update({
             where: { id: runId },
-            data: { score: runScore },
+            data: {
+              score: runScore,
+              ...(run.initialScore == null &&
+              run.score != null &&
+              run.score !== runScore
+                ? { initialScore: run.score }
+                : {}),
+            },
           })
         : null;
 

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -23,8 +23,6 @@ import {
   ChallengeData,
 } from 'src/shared/modules/global/challenge.service';
 import { ResourceApiService } from 'src/shared/modules/global/resource.service';
-import { AiReviewerDecisionMakerService } from 'src/shared/modules/global/ai-reviewer-decision-maker.service';
-import { computeScorecardTotal } from 'src/shared/modules/global/scorecard-score.util';
 import { UserRole } from 'src/shared/enums/userRole.enum';
 import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
 import { LoggerService } from 'src/shared/modules/global/logger.service';
@@ -43,7 +41,6 @@ export class AiWorkflowService {
     private readonly memberPrisma: MemberPrismaService,
     private readonly challengeApiService: ChallengeApiService,
     private readonly resourceApiService: ResourceApiService,
-    private readonly aiReviewerDecisionMaker: AiReviewerDecisionMakerService,
     private readonly giteaService: GiteaService,
     private readonly workflowQueueHandler: WorkflowQueueHandler,
     private readonly challengePrisma: ChallengePrismaService,
@@ -836,52 +833,12 @@ export class AiWorkflowService {
     }
 
     try {
-      const updateData = { ...patchData } as Prisma.aiWorkflowRunUpdateInput & {
-        initialScore?: number | null;
-        completedAt?: Date | null;
-      };
-
-      if (patchData.score !== undefined) {
-        const existingRun = await this.prisma.aiWorkflowRun.findUnique({
-          where: { id: runId },
-          select: {
-            score: true,
-            initialScore: true,
-            completedAt: true,
-            workflow: {
-              select: {
-                scorecard: {
-                  select: {
-                    minimumPassingScore: true,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        // update final score and status when manager updates score
-        if (existingRun) {
-          if (
-            existingRun.initialScore === null &&
-            existingRun.score !== null &&
-            existingRun.score !== patchData.score
-          ) {
-            updateData.initialScore = existingRun.score;
-          }
-
-          if (existingRun.completedAt == null) {
-            updateData.completedAt = new Date();
-          }
-        }
-      }
-
       await this.prisma.aiWorkflowRun.update({
         where: {
           workflowId,
           id: runId,
         },
-        data: updateData,
+        data: { ...patchData },
       });
     } catch (error) {
       if (
@@ -1167,7 +1124,7 @@ export class AiWorkflowService {
 
     if (!user.isMachine) {
       const keys = Object.keys(patchData);
-      const prohibitedKeys = ['content'];
+      const prohibitedKeys = ['content', 'questionScore'];
       if (keys.some((key) => prohibitedKeys.includes(key))) {
         throw new BadRequestException(
           `Users cannot update one of these properties - ${prohibitedKeys.join(',')}`,
@@ -1211,96 +1168,20 @@ export class AiWorkflowService {
       delete patchData.upVote;
     }
 
-    const isPrivilegedRunItemScoreUpdater =
-      !user.isMachine &&
-      Boolean(
-        user.roles?.some(
-          (role) =>
-            role === UserRole.Admin ||
-            role === UserRole.Copilot ||
-            role === UserRole.ProjectManager,
-        ),
-      );
-
+    // Update other properties only allowed for machine users
     const updateData: any = {};
-    if (user.isMachine && patchData.content) {
-      updateData.content = patchData.content;
-    }
-
-    const scoreUpdateRequested = patchData.questionScore !== undefined;
-    const commentText =
-      typeof patchData.comment === 'string'
-        ? patchData.comment.trim()
-        : undefined;
-
-    let runScore: number | null = null;
-
-    if (scoreUpdateRequested) {
-      if (user.isMachine) {
-        updateData.questionScore = patchData.questionScore;
-      } else if (isPrivilegedRunItemScoreUpdater) {
-        if (!commentText) {
-          throw new BadRequestException(
-            'A comment is required when updating question score.',
-          );
-        }
-
-        if (!run.submissionId) {
-          throw new ForbiddenException(
-            'Unable to validate approval phase for this run.',
-          );
-        }
-
-        const submission = await this.prisma.submission.findUnique({
-          where: { id: run.submissionId },
-          select: { challengeId: true },
-        });
-
-        if (!submission?.challengeId) {
-          throw new ForbiddenException(
-            'Unable to validate approval phase for this run.',
-          );
-        }
-
-        const approvalOpen = await this.challengeApiService.isPhaseOpen(
-          submission.challengeId,
-          'Approval',
-        );
-
-        if (!approvalOpen) {
-          throw new ForbiddenException(
-            'Question score edits are only allowed during the approval phase.',
-          );
-        }
-
-        updateData.questionScore = patchData.questionScore;
-        if (
-          runItem.questionScore !== undefined &&
-          runItem.questionScore !== null
-        ) {
-          updateData.originalQuestionScore = runItem.questionScore;
-        }
-      } else {
-        throw new ForbiddenException(
-          'Only machine users or privileged roles may update question score.',
-        );
+    if (user.isMachine) {
+      if (patchData.content) {
+        updateData.content = patchData.content;
       }
-
-      runScore = await this.computeRunScoreForRunItem(
-        workflowId,
-        runId,
-        runItem.scorecardQuestionId,
-        patchData.questionScore as number,
-      );
+      if (patchData.questionScore) {
+        updateData.questionScore = patchData.questionScore;
+      }
     }
 
-    if (commentText && !scoreUpdateRequested) {
-      throw new BadRequestException(
-        'Comment can only be created when updating the question score.',
-      );
-    }
-
-    if (Object.keys(updateData).length === 0 && !commentText) {
+    // If there are no other fields to update
+    // just return the run item
+    if (Object.keys(updateData).length === 0) {
       return this.prisma.aiWorkflowRunItem.findUnique({
         where: { id: itemId },
         include: {
@@ -1310,122 +1191,13 @@ export class AiWorkflowService {
       });
     }
 
-    const itemUpdate = this.prisma.aiWorkflowRunItem.update({
+    return this.prisma.aiWorkflowRunItem.update({
       where: { id: itemId },
-      data: updateData,
-    });
-
-    const runUpdate =
-      scoreUpdateRequested && runScore !== null
-        ? this.prisma.aiWorkflowRun.update({
-            where: { id: runId },
-            data: { score: runScore },
-          })
-        : null;
-
-    let updatedItem;
-
-    if (commentText) {
-      if (!user.userId) {
-        throw new BadRequestException('User id is not available');
-      }
-
-      const transactionItems: any = [
-        itemUpdate,
-        this.prisma.aiWorkflowRunItemComment.create({
-          data: {
-            workflowRunItemId: itemId,
-            content: commentText,
-            userId: user.userId.toString(),
-          },
-        }),
-      ];
-
-      if (runUpdate) {
-        transactionItems.push(runUpdate);
-      }
-
-      const [item] = await this.prisma.$transaction(transactionItems);
-      updatedItem = item;
-    } else if (runUpdate) {
-      const [item] = await this.prisma.$transaction([itemUpdate, runUpdate]);
-      updatedItem = item;
-    } else {
-      updatedItem = await itemUpdate;
-    }
-
-    if (scoreUpdateRequested && run.submissionId) {
-      await this.aiReviewerDecisionMaker.evaluateSubmission(run.submissionId);
-    }
-
-    return this.prisma.aiWorkflowRunItem.findUnique({
-      where: { id: updatedItem.id },
       include: {
         comments: true,
         votes: true,
       },
+      data: updateData,
     });
-  }
-
-  private async computeRunScoreForRunItem(
-    workflowId: string,
-    runId: string,
-    questionId: string,
-    questionScore: number,
-  ): Promise<number | null> {
-    const workflowWithScorecard = await this.prisma.aiWorkflow.findUnique({
-      where: { id: workflowId },
-      select: {
-        scorecard: {
-          select: {
-            scorecardGroups: {
-              select: {
-                weight: true,
-                sections: {
-                  select: {
-                    weight: true,
-                    questions: {
-                      select: {
-                        id: true,
-                        type: true,
-                        scaleMin: true,
-                        scaleMax: true,
-                        weight: true,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    });
-
-    if (!workflowWithScorecard?.scorecard) {
-      return null;
-    }
-
-    const items = await this.prisma.aiWorkflowRunItem.findMany({
-      where: { workflowRunId: runId },
-      select: {
-        scorecardQuestionId: true,
-        questionScore: true,
-      },
-    });
-
-    const answers = new Map(
-      items.map((item) => [
-        item.scorecardQuestionId,
-        item.scorecardQuestionId === questionId
-          ? questionScore
-          : item.questionScore,
-      ]),
-    );
-
-    const scorecard = workflowWithScorecard.scorecard;
-    const totalScore = computeScorecardTotal(scorecard, answers);
-
-    return Math.round((totalScore + Number.EPSILON) * 100) / 100;
   }
 }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -1236,7 +1236,9 @@ export class AiWorkflowService {
         updateData.questionScore = patchData.questionScore;
         if (
           runItem.questionScore !== undefined &&
-          runItem.questionScore !== null
+          runItem.questionScore !== null &&
+          (runItem.originalQuestionScore === null ||
+            runItem.originalQuestionScore === undefined)
         ) {
           updateData.originalQuestionScore = runItem.questionScore;
         }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -23,6 +23,8 @@ import {
   ChallengeData,
 } from 'src/shared/modules/global/challenge.service';
 import { ResourceApiService } from 'src/shared/modules/global/resource.service';
+import { AiReviewerDecisionMakerService } from 'src/shared/modules/global/ai-reviewer-decision-maker.service';
+import { computeScorecardTotal } from 'src/shared/modules/global/scorecard-score.util';
 import { UserRole } from 'src/shared/enums/userRole.enum';
 import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
 import { LoggerService } from 'src/shared/modules/global/logger.service';
@@ -41,6 +43,7 @@ export class AiWorkflowService {
     private readonly memberPrisma: MemberPrismaService,
     private readonly challengeApiService: ChallengeApiService,
     private readonly resourceApiService: ResourceApiService,
+    private readonly aiReviewerDecisionMaker: AiReviewerDecisionMakerService,
     private readonly giteaService: GiteaService,
     private readonly workflowQueueHandler: WorkflowQueueHandler,
     private readonly challengePrisma: ChallengePrismaService,
@@ -1164,7 +1167,7 @@ export class AiWorkflowService {
 
     if (!user.isMachine) {
       const keys = Object.keys(patchData);
-      const prohibitedKeys = ['content', 'questionScore'];
+      const prohibitedKeys = ['content'];
       if (keys.some((key) => prohibitedKeys.includes(key))) {
         throw new BadRequestException(
           `Users cannot update one of these properties - ${prohibitedKeys.join(',')}`,
@@ -1208,20 +1211,96 @@ export class AiWorkflowService {
       delete patchData.upVote;
     }
 
-    // Update other properties only allowed for machine users
+    const isPrivilegedRunItemScoreUpdater =
+      !user.isMachine &&
+      Boolean(
+        user.roles?.some(
+          (role) =>
+            role === UserRole.Admin ||
+            role === UserRole.Copilot ||
+            role === UserRole.ProjectManager,
+        ),
+      );
+
     const updateData: any = {};
-    if (user.isMachine) {
-      if (patchData.content) {
-        updateData.content = patchData.content;
-      }
-      if (patchData.questionScore) {
-        updateData.questionScore = patchData.questionScore;
-      }
+    if (user.isMachine && patchData.content) {
+      updateData.content = patchData.content;
     }
 
-    // If there are no other fields to update
-    // just return the run item
-    if (Object.keys(updateData).length === 0) {
+    const scoreUpdateRequested = patchData.questionScore !== undefined;
+    const commentText =
+      typeof patchData.comment === 'string'
+        ? patchData.comment.trim()
+        : undefined;
+
+    let runScore: number | null = null;
+
+    if (scoreUpdateRequested) {
+      if (user.isMachine) {
+        updateData.questionScore = patchData.questionScore;
+      } else if (isPrivilegedRunItemScoreUpdater) {
+        if (!commentText) {
+          throw new BadRequestException(
+            'A comment is required when updating question score.',
+          );
+        }
+
+        if (!run.submissionId) {
+          throw new ForbiddenException(
+            'Unable to validate approval phase for this run.',
+          );
+        }
+
+        const submission = await this.prisma.submission.findUnique({
+          where: { id: run.submissionId },
+          select: { challengeId: true },
+        });
+
+        if (!submission?.challengeId) {
+          throw new ForbiddenException(
+            'Unable to validate approval phase for this run.',
+          );
+        }
+
+        const approvalOpen = await this.challengeApiService.isPhaseOpen(
+          submission.challengeId,
+          'approval',
+        );
+
+        if (!approvalOpen) {
+          throw new ForbiddenException(
+            'Question score edits are only allowed during the approval phase.',
+          );
+        }
+
+        updateData.questionScore = patchData.questionScore;
+        if (
+          runItem.questionScore !== undefined &&
+          runItem.questionScore !== null
+        ) {
+          updateData.originalQuestionScore = runItem.questionScore;
+        }
+      } else {
+        throw new ForbiddenException(
+          'Only machine users or privileged roles may update question score.',
+        );
+      }
+
+      runScore = await this.computeRunScoreForRunItem(
+        workflowId,
+        runId,
+        runItem.scorecardQuestionId,
+        patchData.questionScore as number,
+      );
+    }
+
+    if (commentText && !scoreUpdateRequested) {
+      throw new BadRequestException(
+        'Comment can only be created when updating the question score.',
+      );
+    }
+
+    if (Object.keys(updateData).length === 0 && !commentText) {
       return this.prisma.aiWorkflowRunItem.findUnique({
         where: { id: itemId },
         include: {
@@ -1231,13 +1310,122 @@ export class AiWorkflowService {
       });
     }
 
-    return this.prisma.aiWorkflowRunItem.update({
+    const itemUpdate = this.prisma.aiWorkflowRunItem.update({
       where: { id: itemId },
+      data: updateData,
+    });
+
+    const runUpdate =
+      scoreUpdateRequested && runScore !== null
+        ? this.prisma.aiWorkflowRun.update({
+            where: { id: runId },
+            data: { score: runScore },
+          })
+        : null;
+
+    let updatedItem;
+
+    if (commentText) {
+      if (!user.userId) {
+        throw new BadRequestException('User id is not available');
+      }
+
+      const transactionItems: any = [
+        itemUpdate,
+        this.prisma.aiWorkflowRunItemComment.create({
+          data: {
+            workflowRunItemId: itemId,
+            content: commentText,
+            userId: user.userId.toString(),
+          },
+        }),
+      ];
+
+      if (runUpdate) {
+        transactionItems.push(runUpdate);
+      }
+
+      const [item] = await this.prisma.$transaction(transactionItems);
+      updatedItem = item;
+    } else if (runUpdate) {
+      const [item] = await this.prisma.$transaction([itemUpdate, runUpdate]);
+      updatedItem = item;
+    } else {
+      updatedItem = await itemUpdate;
+    }
+
+    if (scoreUpdateRequested && run.submissionId) {
+      await this.aiReviewerDecisionMaker.evaluateSubmission(run.submissionId);
+    }
+
+    return this.prisma.aiWorkflowRunItem.findUnique({
+      where: { id: updatedItem.id },
       include: {
         comments: true,
         votes: true,
       },
-      data: updateData,
     });
+  }
+
+  private async computeRunScoreForRunItem(
+    workflowId: string,
+    runId: string,
+    questionId: string,
+    questionScore: number,
+  ): Promise<number | null> {
+    const workflowWithScorecard = await this.prisma.aiWorkflow.findUnique({
+      where: { id: workflowId },
+      select: {
+        scorecard: {
+          select: {
+            scorecardGroups: {
+              select: {
+                weight: true,
+                sections: {
+                  select: {
+                    weight: true,
+                    questions: {
+                      select: {
+                        id: true,
+                        type: true,
+                        scaleMin: true,
+                        scaleMax: true,
+                        weight: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!workflowWithScorecard?.scorecard) {
+      return null;
+    }
+
+    const items = await this.prisma.aiWorkflowRunItem.findMany({
+      where: { workflowRunId: runId },
+      select: {
+        scorecardQuestionId: true,
+        questionScore: true,
+      },
+    });
+
+    const answers = new Map(
+      items.map((item) => [
+        item.scorecardQuestionId,
+        item.scorecardQuestionId === questionId
+          ? questionScore
+          : item.questionScore,
+      ]),
+    );
+
+    const scorecard = workflowWithScorecard.scorecard;
+    const totalScore = computeScorecardTotal(scorecard, answers);
+
+    return Math.round((totalScore + Number.EPSILON) * 100) / 100;
   }
 }

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -1264,7 +1264,7 @@ export class AiWorkflowService {
 
         const approvalOpen = await this.challengeApiService.isPhaseOpen(
           submission.challengeId,
-          'approval',
+          'Approval',
         );
 
         if (!approvalOpen) {

--- a/src/api/review/review.service.ts
+++ b/src/api/review/review.service.ts
@@ -31,6 +31,7 @@ import {
 } from 'src/shared/modules/global/challenge.service';
 import { MemberPrismaService } from 'src/shared/modules/global/member-prisma.service';
 import { LoggerService } from 'src/shared/modules/global/logger.service';
+import { computeScoresFromItems as computeScorecardScoresFromItems } from 'src/shared/modules/global/scorecard-score.util';
 import { JwtUser, isAdmin } from 'src/shared/modules/global/jwt.service';
 import { EventBusService } from 'src/shared/modules/global/eventBus.service';
 import { CommonConfig } from 'src/shared/config/common.config';
@@ -318,107 +319,12 @@ export class ReviewService {
         return { initialScore: null, finalScore: null };
       }
 
-      // Build a quick lookup for answers by questionId
-      const answersByQuestion = new Map(
-        items.map((i) => [i.scorecardQuestionId, i]),
+      const { initialScore, finalScore } = computeScorecardScoresFromItems(
+        scorecard,
+        items,
       );
 
-      // Normalize weights to avoid issues if they don't sum to exactly 100
-      const totalGroupWeight = scorecard.scorecardGroups.reduce(
-        (sum, g) => sum + (g.weight || 0),
-        0,
-      );
-
-      const computeQuestionScore = (
-        type: string,
-        scaleMin: number | null | undefined,
-        scaleMax: number | null | undefined,
-        answer: string | null | undefined,
-      ): number => {
-        if (answer === undefined || answer === null) return 0;
-        const t = String(type).toUpperCase();
-        if (t === 'YES_NO') {
-          return String(answer).toUpperCase() === 'YES' ? 100 : 0;
-        }
-        if (t === 'SCALE' || t === 'TEST_CASE') {
-          const min = typeof scaleMin === 'number' ? scaleMin : 0;
-          const max = typeof scaleMax === 'number' ? scaleMax : 0;
-          const val = Number(answer);
-          if (!isFinite(val)) return 0;
-          if (max === min) return 0;
-          const norm = ((val - min) / (max - min)) * 100;
-          return Math.min(100, Math.max(0, norm));
-        }
-        // Default for unknown types
-        return 0;
-      };
-
-      let initialTotal = 0;
-      let finalTotal = 0;
-
-      for (const group of scorecard.scorecardGroups) {
-        const groupWeightNorm = totalGroupWeight
-          ? (group.weight || 0) / totalGroupWeight
-          : 1 / Math.max(1, scorecard.scorecardGroups.length);
-
-        const totalSectionWeight = group.sections.reduce(
-          (s, sec) => s + (sec.weight || 0),
-          0,
-        );
-
-        let groupInitial = 0;
-        let groupFinal = 0;
-
-        for (const section of group.sections) {
-          const sectionWeightNorm = totalSectionWeight
-            ? (section.weight || 0) / totalSectionWeight
-            : 1 / Math.max(1, group.sections.length);
-
-          const totalQuestionWeight = section.questions.reduce(
-            (s, q) => s + (q.weight || 0),
-            0,
-          );
-
-          let sectionInitial = 0;
-          let sectionFinal = 0;
-
-          for (const q of section.questions) {
-            const questionWeightNorm = totalQuestionWeight
-              ? (q.weight || 0) / totalQuestionWeight
-              : 1 / Math.max(1, section.questions.length);
-
-            const ans = answersByQuestion.get(q.id);
-            const qi = computeQuestionScore(
-              q.type,
-              q.scaleMin ?? null,
-              q.scaleMax ?? null,
-              ans?.initialAnswer ?? null,
-            );
-            const qf = computeQuestionScore(
-              q.type,
-              q.scaleMin ?? null,
-              q.scaleMax ?? null,
-              ans?.finalAnswer ?? ans?.initialAnswer ?? null,
-            );
-
-            sectionInitial += qi * questionWeightNorm;
-            sectionFinal += qf * questionWeightNorm;
-          }
-
-          groupInitial += sectionInitial * sectionWeightNorm;
-          groupFinal += sectionFinal * sectionWeightNorm;
-        }
-
-        initialTotal += groupInitial * groupWeightNorm;
-        finalTotal += groupFinal * groupWeightNorm;
-      }
-
-      // Round to 2 decimals for readability
-      const round2 = (n: number) => Math.round(n * 100) / 100;
-      return {
-        initialScore: round2(initialTotal),
-        finalScore: round2(finalTotal),
-      };
+      return { initialScore, finalScore };
     } catch (e) {
       this.logger.error(
         '[computeScoresFromItems] Failed to compute scores. Returning nulls.',

--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -986,7 +986,7 @@ describe('SubmissionService', () => {
       expect(result.data[1]).not.toHaveProperty('isLatest');
     });
 
-    it('omits review data for non-owned submissions before completion', async () => {
+    it('omits review data and submission id for other submitters while challenge is active', async () => {
       const submissions = [
         {
           id: 'submission-own',
@@ -1043,13 +1043,13 @@ describe('SubmissionService', () => {
         { page: 1, perPage: 50 } as any,
       );
 
-      const own = result.data.find((entry) => entry.id === 'submission-own');
-      const other = result.data.find(
-        (entry) => entry.id === 'submission-other',
-      );
+      const own = result.data.find((entry) => entry.memberId === 'user-1');
+      const other = result.data.find((entry) => entry.memberId === 'user-2');
 
       expect(own?.review).toBeDefined();
+      expect(other).toBeDefined();
       expect(other).not.toHaveProperty('review');
+      expect(other).not.toHaveProperty('id');
       expect(
         resourceApiServiceListMock.getMemberResourcesRoles,
       ).toHaveBeenCalledWith('challenge-1', 'user-1');
@@ -1374,11 +1374,11 @@ describe('SubmissionService', () => {
         { page: 1, perPage: 50 } as any,
       );
 
-      const other = result.data.find(
-        (entry) => entry.id === 'submission-other',
-      );
+      const other = result.data.find((entry) => entry.memberId === 'user-2');
 
+      expect(other).toBeDefined();
       expect(other?.review).toBeDefined();
+      expect(other).not.toHaveProperty('id');
     });
 
     it('masks other reviewers scores while preserving reviewer metadata on active challenges', async () => {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -3572,7 +3572,8 @@ export class SubmissionService {
         ? String(authUser.userId).trim()
         : '';
 
-    const isPrivilegedRequester = authUser && (authUser.isMachine || isAdmin(authUser));
+    const isPrivilegedRequester =
+      authUser && (authUser.isMachine || isAdmin(authUser));
     if (!isPrivilegedRequester && !requesterUserId) {
       for (const submission of submissions) {
         if (Object.prototype.hasOwnProperty.call(submission, 'review')) {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -4634,6 +4634,7 @@ export class SubmissionService {
         continue;
       }
 
+      delete (submission as any).id;
       (submission as any).memberId = null;
       if (Object.prototype.hasOwnProperty.call(submission, 'submitterHandle')) {
         delete (submission as any).submitterHandle;
@@ -4738,6 +4739,7 @@ export class SubmissionService {
         }
       }
 
+      delete (submission as any).id;
       if (Object.prototype.hasOwnProperty.call(submission, 'reviewSummation')) {
         delete (submission as any).reviewSummation;
       }

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -3550,7 +3550,7 @@ export class SubmissionService {
   }
 
   private async applyReviewVisibilityFilters(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<{
       challengeId?: string | null;
       memberId?: string | null;
@@ -3572,7 +3572,7 @@ export class SubmissionService {
         ? String(authUser.userId).trim()
         : '';
 
-    const isPrivilegedRequester = authUser?.isMachine || isAdmin(authUser);
+    const isPrivilegedRequester = authUser && (authUser.isMachine || isAdmin(authUser));
     if (!isPrivilegedRequester && !requesterUserId) {
       for (const submission of submissions) {
         if (Object.prototype.hasOwnProperty.call(submission, 'review')) {
@@ -4557,7 +4557,7 @@ export class SubmissionService {
   }
 
   private stripSubmitterMemberIds(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<
       { challengeId?: string | null; memberId?: string | null } & Record<
         string,
@@ -4569,7 +4569,7 @@ export class SubmissionService {
     if (!submissions.length) {
       return;
     }
-    if (authUser?.isMachine || isAdmin(authUser)) {
+    if (authUser && (authUser.isMachine || isAdmin(authUser))) {
       return;
     }
 
@@ -4648,7 +4648,7 @@ export class SubmissionService {
   }
 
   private stripSubmitterSubmissionDetails(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<
       {
         challengeId?: string | null;
@@ -4663,7 +4663,7 @@ export class SubmissionService {
     if (!submissions.length) {
       return;
     }
-    if (authUser?.isMachine || isAdmin(authUser)) {
+    if (authUser && (authUser.isMachine || isAdmin(authUser))) {
       return;
     }
 
@@ -4758,7 +4758,7 @@ export class SubmissionService {
    * Used by `listSubmission` so competitors can see their own test progress without per-seed scores.
    */
   private sanitizeMemberVisibleReviewSummationMetadata(
-    authUser: JwtUser,
+    authUser: JwtUser | undefined,
     submissions: Array<
       {
         challengeId?: string | null;
@@ -4770,7 +4770,7 @@ export class SubmissionService {
     if (!submissions.length) {
       return;
     }
-    if (authUser?.isMachine || isAdmin(authUser)) {
+    if (authUser && (authUser.isMachine || isAdmin(authUser))) {
       return;
     }
 

--- a/src/dto/aiReviewDecision.dto.ts
+++ b/src/dto/aiReviewDecision.dto.ts
@@ -1,15 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsOptional,
-  IsString,
-  IsEnum,
-  IsNumber,
-  IsArray,
-  ValidateNested,
-  Min,
-  Max,
-} from 'class-validator';
-import { Transform, Type } from 'class-transformer';
+import { IsOptional, IsString, IsEnum } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { AiReviewDecisionEscalationResponseDto } from './aiReviewEscalation.dto';
 
 const trimTransformer = ({ value }: { value: unknown }): string | undefined =>
@@ -125,59 +116,4 @@ export class AiReviewDecisionResponseDto {
     type: [AiReviewDecisionEscalationResponseDto],
   })
   escalations?: AiReviewDecisionEscalationResponseDto[];
-
-  @ApiProperty({
-    description: 'Manager comment left during the Approval phase',
-    required: false,
-    nullable: true,
-  })
-  managerComment: string | null;
-}
-
-export class WorkflowManagerOverrideDto {
-  @ApiProperty({ description: 'Workflow ID to override' })
-  @IsString()
-  workflowId: string;
-
-  @ApiProperty({
-    description: 'Manager score override (0–100)',
-    required: false,
-    nullable: true,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Max(100)
-  managerScore?: number | null;
-
-  @ApiProperty({
-    description: 'Manager comment for this workflow entry',
-    required: false,
-    nullable: true,
-  })
-  @IsOptional()
-  @IsString()
-  workflowComment?: string | null;
-}
-
-export class PatchAiReviewDecisionDto {
-  @ApiProperty({
-    description: 'Overall manager comment for this decision',
-    required: false,
-    nullable: true,
-  })
-  @IsOptional()
-  @IsString()
-  managerComment?: string | null;
-
-  @ApiProperty({
-    description: 'Per-workflow score/comment overrides',
-    required: false,
-    type: [WorkflowManagerOverrideDto],
-  })
-  @IsOptional()
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => WorkflowManagerOverrideDto)
-  workflowOverrides?: WorkflowManagerOverrideDto[];
 }

--- a/src/dto/aiWorkflow.dto.ts
+++ b/src/dto/aiWorkflow.dto.ts
@@ -194,6 +194,13 @@ export class CommentDto {
 export class UpdateAiWorkflowRunItemDto extends PartialType(
   CreateAiWorkflowRunItemDto,
 ) {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @Transform(trimTransformer)
+  @IsNotEmpty()
+  comment?: string;
+
   @ApiHideProperty()
   @IsEmpty({ message: 'scorecardQuestionId cannot be updated' })
   scorecardQuestionId?: never;

--- a/src/shared/modules/global/scorecard-score.util.ts
+++ b/src/shared/modules/global/scorecard-score.util.ts
@@ -1,0 +1,162 @@
+export type ScorecardQuestionAnswer = string | number | null | undefined;
+
+const round2 = (value: number): number => Math.round((value + Number.EPSILON) * 100) / 100;
+
+export const computeQuestionScore = (
+  type: string | null | undefined,
+  scaleMin: number | null | undefined,
+  scaleMax: number | null | undefined,
+  answer: ScorecardQuestionAnswer,
+): number => {
+  if (answer === undefined || answer === null) {
+    return 0;
+  }
+
+  const normalizedType = String(type ?? '').toUpperCase();
+  if (normalizedType === 'YES_NO') {
+    return String(answer).toUpperCase() === 'YES' || answer === 1 ? 100 : 0;
+  }
+
+  if (normalizedType === 'SCALE' || normalizedType === 'TEST_CASE') {
+    const min = typeof scaleMin === 'number' ? scaleMin : 0;
+    const max = typeof scaleMax === 'number' ? scaleMax : 0;
+    const numericAnswer = typeof answer === 'number' ? answer : Number(answer);
+    if (!Number.isFinite(numericAnswer) || max === min) {
+      return 0;
+    }
+
+    const normalized = ((numericAnswer - min) / (max - min)) * 100;
+    return Math.min(100, Math.max(0, normalized));
+  }
+
+  return 0;
+};
+
+export const computeScorecardTotal = (
+  scorecard: {
+    scorecardGroups?: Array<{
+      weight?: number | null;
+      sections?: Array<{
+        weight?: number | null;
+        questions?: Array<{
+          id: string;
+          type?: string | null;
+          scaleMin?: number | null;
+          scaleMax?: number | null;
+          weight?: number | null;
+        }>;
+      }>;
+    }>;
+  },
+  answers: Map<string, ScorecardQuestionAnswer>,
+): number => {
+  if (!scorecard?.scorecardGroups?.length) {
+    return 0;
+  }
+
+  const totalGroupWeight = scorecard.scorecardGroups.reduce(
+    (sum, group) => sum + (group.weight ?? 0),
+    0,
+  );
+
+  let totalScore = 0;
+
+  for (const group of scorecard.scorecardGroups) {
+    const groupWeightNorm = totalGroupWeight
+      ? (group.weight ?? 0) / totalGroupWeight
+      : 1 / Math.max(1, scorecard.scorecardGroups.length);
+
+    const totalSectionWeight = group.sections?.reduce(
+      (sum, section) => sum + (section.weight ?? 0),
+      0,
+    ) ?? 0;
+
+    let groupScore = 0;
+
+    for (const section of group.sections ?? []) {
+      const sectionWeightNorm = totalSectionWeight
+        ? (section.weight ?? 0) / totalSectionWeight
+        : 1 / Math.max(1, group.sections?.length ?? 1);
+
+      const totalQuestionWeight = section.questions?.reduce(
+        (sum, question) => sum + (question.weight ?? 0),
+        0,
+      ) ?? 0;
+
+      let sectionScore = 0;
+
+      for (const question of section.questions ?? []) {
+        const questionWeightNorm = totalQuestionWeight
+          ? (question.weight ?? 0) / totalQuestionWeight
+          : 1 / Math.max(1, section.questions?.length ?? 1);
+
+        const answer = answers.get(question.id) ?? null;
+        const questionValue = computeQuestionScore(
+          question.type ?? null,
+          question.scaleMin ?? null,
+          question.scaleMax ?? null,
+          answer,
+        );
+
+        sectionScore += questionValue * questionWeightNorm;
+      }
+
+      groupScore += sectionScore * sectionWeightNorm;
+    }
+
+    totalScore += groupScore * groupWeightNorm;
+  }
+
+  return round2(totalScore);
+};
+
+export const computeScoresFromItems = <
+  Item extends {
+    scorecardQuestionId: string;
+    initialAnswer?: ScorecardQuestionAnswer;
+    finalAnswer?: ScorecardQuestionAnswer;
+  },
+>(
+  scorecard: {
+    scorecardGroups?: Array<{
+      weight?: number | null;
+      sections?: Array<{
+        weight?: number | null;
+        questions?: Array<{
+          id: string;
+          type?: string | null;
+          scaleMin?: number | null;
+          scaleMax?: number | null;
+          weight?: number | null;
+        }>;
+      }>;
+    }>;
+  },
+  items: Item[],
+): { initialScore: number | null; finalScore: number | null } => {
+  const answersByQuestion = new Map(items.map((item) => [item.scorecardQuestionId, item]));
+
+  const initialAnswers = new Map<string, ScorecardQuestionAnswer>();
+  const finalAnswers = new Map<string, ScorecardQuestionAnswer>();
+
+  for (const group of scorecard.scorecardGroups ?? []) {
+    for (const section of group.sections ?? []) {
+      for (const question of section.questions ?? []) {
+        const item = answersByQuestion.get(question.id);
+        initialAnswers.set(
+          question.id,
+          item?.initialAnswer ?? null,
+        );
+        finalAnswers.set(
+          question.id,
+          item?.finalAnswer ?? item?.initialAnswer ?? null,
+        );
+      }
+    }
+  }
+
+  return {
+    initialScore: computeScorecardTotal(scorecard, initialAnswers),
+    finalScore: computeScorecardTotal(scorecard, finalAnswers),
+  };
+};

--- a/src/shared/modules/global/scorecard-score.util.ts
+++ b/src/shared/modules/global/scorecard-score.util.ts
@@ -1,6 +1,7 @@
 export type ScorecardQuestionAnswer = string | number | null | undefined;
 
-const round2 = (value: number): number => Math.round((value + Number.EPSILON) * 100) / 100;
+const round2 = (value: number): number =>
+  Math.round((value + Number.EPSILON) * 100) / 100;
 
 export const computeQuestionScore = (
   type: string | null | undefined,
@@ -66,10 +67,11 @@ export const computeScorecardTotal = (
       ? (group.weight ?? 0) / totalGroupWeight
       : 1 / Math.max(1, scorecard.scorecardGroups.length);
 
-    const totalSectionWeight = group.sections?.reduce(
-      (sum, section) => sum + (section.weight ?? 0),
-      0,
-    ) ?? 0;
+    const totalSectionWeight =
+      group.sections?.reduce(
+        (sum, section) => sum + (section.weight ?? 0),
+        0,
+      ) ?? 0;
 
     let groupScore = 0;
 
@@ -78,10 +80,11 @@ export const computeScorecardTotal = (
         ? (section.weight ?? 0) / totalSectionWeight
         : 1 / Math.max(1, group.sections?.length ?? 1);
 
-      const totalQuestionWeight = section.questions?.reduce(
-        (sum, question) => sum + (question.weight ?? 0),
-        0,
-      ) ?? 0;
+      const totalQuestionWeight =
+        section.questions?.reduce(
+          (sum, question) => sum + (question.weight ?? 0),
+          0,
+        ) ?? 0;
 
       let sectionScore = 0;
 
@@ -134,7 +137,9 @@ export const computeScoresFromItems = <
   },
   items: Item[],
 ): { initialScore: number | null; finalScore: number | null } => {
-  const answersByQuestion = new Map(items.map((item) => [item.scorecardQuestionId, item]));
+  const answersByQuestion = new Map(
+    items.map((item) => [item.scorecardQuestionId, item]),
+  );
 
   const initialAnswers = new Map<string, ScorecardQuestionAnswer>();
   const finalAnswers = new Map<string, ScorecardQuestionAnswer>();
@@ -143,10 +148,7 @@ export const computeScoresFromItems = <
     for (const section of group.sections ?? []) {
       for (const question of section.questions ?? []) {
         const item = answersByQuestion.get(question.id);
-        initialAnswers.set(
-          question.id,
-          item?.initialAnswer ?? null,
-        );
+        initialAnswers.set(question.id, item?.initialAnswer ?? null);
         finalAnswers.set(
           question.id,
           item?.finalAnswer ?? item?.initialAnswer ?? null,


### PR DESCRIPTION
This pull request removes the manager override functionality from AI review decisions, simplifies related code, and introduces a new field to track the original score in AI workflow run items. It also refactors score calculation for reviews and improves submission data privacy in the API and tests.

**AI Review Decision: Removal of Manager Override Functionality**
- Removed the ability for Admins/Copilots to patch AI review decisions, including the manager comment and workflow score overrides. This includes deleting the PATCH endpoint and all related service logic (`patch` method), as well as removing the `managerComment` field from both the Prisma schema and API layer.

**AI Workflow Run Item: Schema Update**
- Added a new `originalQuestionScore` field to the `aiWorkflowRunItem` model and database table to preserve the initial score for each workflow run item.

**Review Score Calculation: Refactoring**
- Refactored review score calculation by replacing inline logic with a utility function (`computeScorecardScoresFromItems`), improving maintainability and consistency. 

**Submission Service: Privacy Improvements**
- Enhanced submission data privacy by omitting the `id` and `review` fields for submissions not owned by the requester while a challenge is active, and by making the visibility filter and submitter member ID stripping functions tolerant of an undefined user.

**Tests: Update to Match Submission Privacy**
- Updated submission service tests to verify that non-owned submissions do not expose `id` or `review` fields to other users while challenges are active. 