### PR TITLE
PM-5231: Add clean validation submission upload

### DIFF
--- a/src/api/submission/submission.controller.ts
+++ b/src/api/submission/submission.controller.ts
@@ -193,6 +193,67 @@ export class SubmissionController {
     return this.service.createManualSubmissionUpload(authUser, body, file);
   }
 
+  @Post('/validation-upload')
+  @Roles(UserRole.Admin)
+  @Scopes(Scope.CreateSubmission)
+  @ApiOperation({
+    summary: 'Upload and create a clean validation submission as Admin/M2M',
+    description:
+      'Roles: Admin (M2M allowed via scope). Uploads file contents directly to clean submission storage and creates a downloadable submission row without phase, submitter, counter, scan, or notification side effects. Intended for Marathon Match scorer validation before challenge launch. | Scopes: create:submission',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Validation submission uploaded and created successfully.',
+    type: SubmissionResponseDto,
+  })
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+    }),
+  )
+  @ApiBody({
+    required: true,
+    type: 'multipart/form-data',
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+        fileName: {
+          type: 'string',
+        },
+        challengeId: {
+          type: 'string',
+        },
+        type: {
+          type: 'string',
+        },
+        memberId: {
+          type: 'number',
+        },
+        submissionPhaseId: {
+          type: 'string',
+        },
+        submittedDate: {
+          type: 'string',
+          format: 'date-time',
+        },
+      },
+      required: ['file', 'challengeId', 'type', 'memberId'],
+    },
+  })
+  async validationUploadSubmission(
+    @Req() req: Request,
+    @UploadedFile() file: Express.Multer.File,
+    @Body() body: ManualSubmissionUploadRequestDto,
+  ): Promise<SubmissionResponseDto> {
+    const authUser: JwtUser = req['user'] as JwtUser;
+    return this.service.createValidationSubmissionUpload(authUser, body, file);
+  }
+
   @Patch('/:submissionId')
   @Roles(UserRole.Admin)
   @Scopes(Scope.UpdateSubmission)

--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -92,6 +92,161 @@ describe('SubmissionService', () => {
     }
   });
 
+  describe('createValidationSubmissionUpload', () => {
+    const createValidationService = () => {
+      const prisma = {
+        submission: {
+          create: jest.fn(),
+        },
+      };
+      const prismaErrorService = {
+        handleError: jest.fn(),
+      };
+      const challengeApiService = {
+        validateChallengeExists: jest.fn(),
+      };
+      const validationResourceApiService = {
+        getMemberResourcesRoles: jest.fn(),
+        validateSubmitterRegistration: jest.fn(),
+      };
+      const challengeCatalogService = {
+        ensureSubmissionTypeAllowed: jest.fn(),
+      };
+      const validationService = new SubmissionService(
+        prisma as any,
+        prismaErrorService as any,
+        {} as any,
+        challengeApiService as any,
+        validationResourceApiService as any,
+        {} as any,
+        {} as any,
+        challengeCatalogService as any,
+        {} as any,
+      );
+
+      return {
+        challengeApiService,
+        challengeCatalogService,
+        prisma,
+        validationResourceApiService,
+        validationService,
+      };
+    };
+
+    it('creates a clean active validation submission without submitter registration checks', async () => {
+      const {
+        challengeApiService,
+        challengeCatalogService,
+        prisma,
+        validationResourceApiService,
+        validationService,
+      } = createValidationService();
+      const submittedDate = new Date('2026-06-01T00:00:00.000Z');
+
+      challengeApiService.validateChallengeExists.mockResolvedValue({
+        id: 'challenge-abc',
+        track: 'DATA_SCIENCE',
+        type: 'Marathon Match',
+      });
+      jest
+        .spyOn(
+          validationService as any,
+          'uploadValidationSubmissionFileToClean',
+        )
+        .mockResolvedValue({
+          fileName: 'solution.zip',
+          fileSize: 12,
+          fileType: 'zip',
+          url: 'https://s3.amazonaws.com/clean/validation/challenge-abc/member-1/solution.zip',
+        });
+      prisma.submission.create.mockResolvedValue({
+        challengeId: 'challenge-abc',
+        createdBy: 'machine-token',
+        eventRaised: true,
+        fileSize: 12,
+        fileType: 'zip',
+        id: 'submission-1',
+        isFileSubmission: true,
+        memberId: 'member-1',
+        status: SubmissionStatus.ACTIVE,
+        submittedDate,
+        systemFileName: 'solution.zip',
+        type: SubmissionType.CONTEST_SUBMISSION,
+        updatedBy: 'machine-token',
+        url: 'https://s3.amazonaws.com/clean/validation/challenge-abc/member-1/solution.zip',
+        viewCount: 0,
+        virusScan: true,
+      });
+
+      const result = await validationService.createValidationSubmissionUpload(
+        {
+          isMachine: true,
+          scopes: ['create:submission'],
+        } as any,
+        {
+          challengeId: 'challenge-abc',
+          memberId: 'member-1',
+          submittedDate: submittedDate.toISOString(),
+          type: SubmissionType.CONTEST_SUBMISSION,
+        },
+        {
+          buffer: Buffer.from('zip'),
+          mimetype: 'application/zip',
+          originalname: 'solution.zip',
+          size: 12,
+        } as Express.Multer.File,
+      );
+
+      expect(result.id).toBe('submission-1');
+      expect(challengeApiService.validateChallengeExists).toHaveBeenCalledWith(
+        'challenge-abc',
+      );
+      expect(
+        challengeCatalogService.ensureSubmissionTypeAllowed,
+      ).toHaveBeenCalledWith(
+        SubmissionType.CONTEST_SUBMISSION,
+        expect.objectContaining({ id: 'challenge-abc' }),
+      );
+      expect(
+        validationResourceApiService.validateSubmitterRegistration,
+      ).not.toHaveBeenCalled();
+      expect(prisma.submission.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          challengeId: 'challenge-abc',
+          eventRaised: true,
+          isFileSubmission: true,
+          memberId: 'member-1',
+          status: SubmissionStatus.ACTIVE,
+          type: SubmissionType.CONTEST_SUBMISSION,
+          virusScan: true,
+        }),
+      });
+    });
+
+    it('rejects validation upload requests without file contents', async () => {
+      const { validationService } = createValidationService();
+
+      await expect(
+        validationService.createValidationSubmissionUpload(
+          {
+            isMachine: true,
+            scopes: ['create:submission'],
+          } as any,
+          {
+            challengeId: 'challenge-abc',
+            memberId: 'member-1',
+            type: SubmissionType.CONTEST_SUBMISSION,
+          },
+          {
+            buffer: Buffer.alloc(0),
+            originalname: 'solution.zip',
+            size: 0,
+          } as Express.Multer.File,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
   describe('listArtifacts', () => {
     it('filters internal artifacts for submission owners', async () => {
       const result = await service.listArtifacts(

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -266,6 +266,127 @@ export class SubmissionService {
     });
   }
 
+  /**
+   * Creates a clean, downloadable submission row for scorer validation without
+   * normal submission lifecycle side effects.
+   * @param authUser Authenticated admin or M2M token with create:submission access.
+   * @param body Validation upload metadata containing challenge, member, and submission type.
+   * @param file Uploaded submission artifact.
+   * @returns Created validation submission response.
+   * @throws ForbiddenException When the caller is not admin-capable.
+   * @throws BadRequestException When the file, challenge, or submission type is invalid.
+   * @throws InternalServerErrorException When clean storage upload or persistence fails.
+   * Used by Marathon Match API to run pre-launch scorer validation through ECS.
+   */
+  async createValidationSubmissionUpload(
+    authUser: JwtUser,
+    body: ManualSubmissionUploadRequestDto,
+    file: Express.Multer.File,
+  ): Promise<SubmissionResponseDto> {
+    if (!isAdmin(authUser)) {
+      throw new ForbiddenException({
+        message:
+          'Only admins or M2M tokens can use validation submission upload.',
+        code: 'FORBIDDEN_VALIDATION_SUBMISSION_UPLOAD',
+      });
+    }
+
+    const hasUploadedFile =
+      !!file &&
+      ((typeof file.size === 'number' && file.size > 0) ||
+        (file.buffer && file.buffer.length > 0));
+
+    if (!hasUploadedFile) {
+      throw new BadRequestException({
+        message: 'File contents are required for validation submission upload.',
+        code: 'VALIDATION_SUBMISSION_FILE_REQUIRED',
+      });
+    }
+
+    await this.ensureChallengeWhitelistAccess(authUser, body.challengeId);
+
+    let challengeDetails: ChallengeData;
+    try {
+      challengeDetails = await this.challengeApiService.validateChallengeExists(
+        body.challengeId,
+      );
+      this.challengeCatalogService.ensureSubmissionTypeAllowed(
+        body.type as SubmissionType,
+        challengeDetails,
+      );
+    } catch (error) {
+      throw new BadRequestException({
+        message: error instanceof Error ? error.message : String(error ?? ''),
+        code: 'INVALID_VALIDATION_SUBMISSION_CONTEXT',
+        details: {
+          challengeId: body.challengeId,
+          memberId: body.memberId,
+          submissionType: body.type,
+        },
+      });
+    }
+
+    const cleanUpload = await this.uploadValidationSubmissionFileToClean(
+      authUser,
+      body,
+      file,
+    );
+    const actor =
+      authUser.userId != null && String(authUser.userId).trim().length > 0
+        ? String(authUser.userId).trim()
+        : 'machine-token';
+    const submittedDate = body.submittedDate
+      ? new Date(body.submittedDate)
+      : new Date();
+
+    if (Number.isNaN(submittedDate.getTime())) {
+      throw new BadRequestException({
+        message: 'Submitted date is invalid.',
+        code: 'INVALID_SUBMITTED_DATE',
+      });
+    }
+
+    try {
+      const data = await this.prisma.submission.create({
+        data: {
+          challengeId: body.challengeId,
+          createdBy: actor,
+          eventRaised: true,
+          fileSize: cleanUpload.fileSize,
+          fileType: cleanUpload.fileType,
+          isFileSubmission: true,
+          memberId: body.memberId,
+          status: SubmissionStatus.ACTIVE,
+          submissionPhaseId: body.submissionPhaseId,
+          submittedDate,
+          systemFileName: cleanUpload.fileName,
+          type: body.type as SubmissionType,
+          updatedBy: actor,
+          url: cleanUpload.url,
+          viewCount: 0,
+          virusScan: true,
+        },
+      });
+
+      this.logger.log(
+        `Validation submission upload stored clean file for challenge ${body.challengeId}, member ${body.memberId}, file ${cleanUpload.fileName}`,
+      );
+
+      return this.buildResponse(data);
+    } catch (error) {
+      const errorResponse = this.prismaErrorService.handleError(
+        error,
+        `creating validation submission for challengeId: ${body.challengeId}, memberId: ${body.memberId}`,
+        body,
+      );
+      throw new InternalServerErrorException({
+        message: errorResponse.message,
+        code: errorResponse.code,
+        details: errorResponse.details,
+      });
+    }
+  }
+
   async ensurePendingReviewsForSubmission(
     submissionId: string,
     options?: {
@@ -1730,6 +1851,106 @@ export class SubmissionService {
 
     return {
       url: this.buildS3HttpUrl(dmzBucket, key),
+      fileName: safeFileName,
+      fileSize:
+        typeof file.size === 'number'
+          ? file.size
+          : file.buffer
+            ? file.buffer.length
+            : null,
+      fileType,
+    };
+  }
+
+  /**
+   * Uploads a validation submission artifact directly into clean submission storage.
+   * @param authUser Authenticated admin or M2M caller used for S3 metadata.
+   * @param body Validation upload request metadata.
+   * @param file Uploaded submission file.
+   * @returns Clean S3 URL and file metadata for the submission row.
+   * @throws InternalServerErrorException When clean bucket configuration or upload fails.
+   * Used by `createValidationSubmissionUpload` so ECS scorer validation can download immediately.
+   */
+  private async uploadValidationSubmissionFileToClean(
+    authUser: JwtUser,
+    body: ManualSubmissionUploadRequestDto,
+    file: Express.Multer.File,
+  ): Promise<SubmissionDmzUploadResult> {
+    const cleanBucket = process.env.SUBMISSION_CLEAN_S3_BUCKET;
+    if (!cleanBucket) {
+      this.logger.error('SUBMISSION_CLEAN_S3_BUCKET is not configured');
+      throw new InternalServerErrorException({
+        message: 'S3 bucket not configured',
+        code: 'CLEAN_BUCKET_MISSING',
+      });
+    }
+
+    const requestedName =
+      body.fileName || file.originalname || file.filename || 'submission';
+    let safeFileName =
+      this.sanitizeArtifactFileName(requestedName) ??
+      `submission-${randomUUID()}`;
+    if (!/\.[A-Za-z0-9]+$/.test(safeFileName)) {
+      const ext = this.guessExtFromMime(file.mimetype) ?? 'bin';
+      safeFileName = `${safeFileName}.${ext}`;
+    }
+
+    const challengeSegment = this.sanitizeS3PathSegment(
+      body.challengeId,
+      'challenge',
+    );
+    const memberSegment = this.sanitizeS3PathSegment(body.memberId, 'member');
+    const key = `validation/${challengeSegment}/${memberSegment}/${randomUUID()}-${safeFileName}`;
+
+    const bodyStream = await this.resolveUploadedFileBody(file);
+    const s3 = this.getS3Client();
+    const actor =
+      authUser.userId != null && String(authUser.userId).trim().length > 0
+        ? String(authUser.userId).trim()
+        : 'machine-token';
+
+    const upload = new Upload({
+      client: s3,
+      params: {
+        Bucket: cleanBucket,
+        Key: key,
+        Body: bodyStream,
+        ContentType: file.mimetype || 'application/octet-stream',
+        Metadata: {
+          challengeId: String(body.challengeId),
+          memberId: String(body.memberId),
+          originalFileName: safeFileName,
+          uploadedBy: actor,
+          uploadPurpose: 'marathon-match-validation',
+        },
+      },
+      queueSize: 4,
+      partSize: 5 * 1024 * 1024,
+      leavePartsOnError: false,
+    });
+
+    try {
+      await upload.done();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to upload validation submission file to clean bucket ${cleanBucket}: ${message}`,
+      );
+      throw new InternalServerErrorException({
+        message: 'Failed to upload validation submission file to clean storage',
+        code: 'CLEAN_UPLOAD_FAILED',
+        details: {
+          challengeId: body.challengeId,
+          memberId: body.memberId,
+        },
+      });
+    }
+
+    const fileTypeMatch = safeFileName.match(/\.([A-Za-z0-9]+)$/);
+    const fileType = fileTypeMatch?.[1]?.toLowerCase() ?? null;
+
+    return {
+      url: this.buildS3HttpUrl(cleanBucket, key),
       fileName: safeFileName,
       fileSize:
         typeof file.size === 'number'


### PR DESCRIPTION
What was broken

Marathon Match scorer validation could not create a downloadable test submission before launch because Review API uploads either followed normal submission lifecycle checks or went to DMZ storage.

Root cause

The ECS scorer downloads clean submissions, while manual upload creates normal submissions through DMZ, phase, submitter, counter, scan, and notification side effects that are not appropriate for pre-launch validation.

What was changed

Added an admin/M2M validation-upload endpoint that stores the uploaded file directly in clean submission storage and creates an active file submission row without normal lifecycle side effects.

Any added/updated tests

Added unit tests for clean validation submission creation and missing-file rejection.
