### PR TITLE
Consider timeout as terminal status, when fetching latest runs, move nulls to end

### DIFF
--- a/src/shared/modules/global/ai-reviewer-decision-maker.service.ts
+++ b/src/shared/modules/global/ai-reviewer-decision-maker.service.ts
@@ -8,6 +8,7 @@ const TERMINAL_RUN_STATUSES = new Set([
   'FAILURE',
   'CANCELLED',
   'COMPLETED',
+  'TIMEOUT',
 ]);
 
 type DecisionContextWorkflow = {
@@ -269,7 +270,10 @@ export class AiReviewerDecisionMakerService {
             startedAt: true,
             completedAt: true,
           },
-          orderBy: [{ startedAt: 'desc' }, { completedAt: 'desc' }],
+          orderBy: [
+            { startedAt: { sort: 'desc', nulls: 'last' } },
+            { completedAt: { sort: 'desc', nulls: 'last' } },
+          ],
         })) as WorkflowRunRow[])
       : [];
 


### PR DESCRIPTION
This pull request updates the `ai-reviewer-decision-maker.service.ts` to improve workflow run status handling and workflow run ordering. The main changes are the addition of a new terminal status and enhanced ordering logic for workflow runs.

**Workflow run status improvements:**

* Added `'TIMEOUT'` to the `TERMINAL_RUN_STATUSES` set to recognize workflow runs that end due to a timeout as terminal states.

**Workflow run ordering enhancements:**

* Updated the `orderBy` clause when fetching workflow runs to explicitly sort by `startedAt` and `completedAt` in descending order, placing `null` values last for both fields. This ensures more predictable and correct ordering when some timestamps are missing.