### PR TITLE
Prevent downloading all artifacts

### DIFF
--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -971,12 +971,19 @@ export class AiWorkflowService {
     );
 
     const [owner, repo] = workflow.gitOwnerRepo.split('/');
-    const artifacts = await this.giteaService.getWorkflowRunArtifacts(
-      owner,
-      repo,
-      +run.gitRunId,
-    );
-    return artifacts;
+    try {
+      return await this.giteaService.getWorkflowRunArtifacts(
+        owner,
+        repo,
+        +run.gitRunId,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to get workflow run attachments for run ${runId} (workflowId=${workflowId}, owner=${owner}, repo=${repo}, gitRunId=${run.gitRunId}). Error=${(error as Error).message}`,
+        (error as Error).stack ?? String(error),
+      );
+      return [];
+    }
   }
 
   async downloadWorkflowRunAttachment(

--- a/src/shared/modules/global/gitea.service.ts
+++ b/src/shared/modules/global/gitea.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   HttpExceptionOptions,
   Injectable,
   InternalServerErrorException,
@@ -182,6 +183,12 @@ export class GiteaService {
   }
 
   async getWorkflowRunArtifacts(owner: string, repo: string, gitJobId: number) {
+    if (!Number.isFinite(gitJobId) || gitJobId <= 0) {
+      throw new BadRequestException(
+        `Invalid gitJobId: ${gitJobId}. Expected a positive finite job ID.`,
+      );
+    }
+
     try {
       const response = await this.giteaClient.repos.getArtifactsOfRun(
         owner,


### PR DESCRIPTION
This pull request improves error handling and input validation related to fetching workflow run artifacts from Gitea. The main focus is to ensure that invalid job IDs are caught early and that errors during artifact retrieval are logged and handled gracefully.

**Error handling and validation improvements:**

* Added input validation in `GiteaService.getWorkflowRunArtifacts` to throw a `BadRequestException` if the provided `gitJobId` is not a positive finite number, preventing invalid requests from being processed.
* Updated `AiWorkflowService` to wrap calls to `getWorkflowRunArtifacts` in a try/catch block, logging detailed error information and returning an empty array if artifact retrieval fails. This ensures that errors are handled gracefully and do not disrupt the workflow.
* Imported `BadRequestException` in `gitea.service.ts` to support the new input validation logic.