### PR TITLE
Hotfix artifacts and wh handling

### DIFF
--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -968,12 +968,19 @@ export class AiWorkflowService {
     );
 
     const [owner, repo] = workflow.gitOwnerRepo.split('/');
-    const artifacts = await this.giteaService.getWorkflowRunArtifacts(
-      owner,
-      repo,
-      +run.gitRunId,
-    );
-    return artifacts;
+    try {
+      return await this.giteaService.getWorkflowRunArtifacts(
+        owner,
+        repo,
+        +run.gitRunId,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to get workflow run attachments for run ${runId} (workflowId=${workflowId}, owner=${owner}, repo=${repo}, gitRunId=${run.gitRunId}). Error=${(error as Error).message}`,
+        (error as Error).stack ?? String(error),
+      );
+      return [];
+    }
   }
 
   async downloadWorkflowRunAttachment(

--- a/src/shared/modules/global/ai-reviewer-decision-maker.service.ts
+++ b/src/shared/modules/global/ai-reviewer-decision-maker.service.ts
@@ -8,6 +8,7 @@ const TERMINAL_RUN_STATUSES = new Set([
   'FAILURE',
   'CANCELLED',
   'COMPLETED',
+  'TIMEOUT',
 ]);
 
 type DecisionContextWorkflow = {
@@ -269,7 +270,10 @@ export class AiReviewerDecisionMakerService {
             startedAt: true,
             completedAt: true,
           },
-          orderBy: [{ startedAt: 'desc' }, { completedAt: 'desc' }],
+          orderBy: [
+            { startedAt: { sort: 'desc', nulls: 'last' } },
+            { completedAt: { sort: 'desc', nulls: 'last' } },
+          ],
         })) as WorkflowRunRow[])
       : [];
 

--- a/src/shared/modules/global/gitea.service.ts
+++ b/src/shared/modules/global/gitea.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   HttpExceptionOptions,
   Injectable,
   InternalServerErrorException,
@@ -182,6 +183,12 @@ export class GiteaService {
   }
 
   async getWorkflowRunArtifacts(owner: string, repo: string, gitJobId: number) {
+    if (!Number.isFinite(gitJobId) || gitJobId <= 0) {
+      throw new BadRequestException(
+        `Invalid gitJobId: ${gitJobId}. Expected a positive finite job ID.`,
+      );
+    }
+
     try {
       const response = await this.giteaClient.repos.getArtifactsOfRun(
         owner,


### PR DESCRIPTION
This pull request introduces improvements to error handling and data consistency in workflow and reviewer decision logic. The main changes include enhanced error logging and handling when fetching workflow artifacts, stricter validation of workflow run IDs, support for additional workflow statuses, and improved ordering of workflow runs.

**Error handling and validation improvements:**

* Added a try/catch block and detailed error logging in `AiWorkflowService.getWorkflowRunAttachments`, returning an empty array on failure instead of propagating errors.
* Added validation for `gitJobId` in `GiteaService.getWorkflowRunArtifacts`, throwing a `BadRequestException` if the ID is not a positive finite number. [[1]](diffhunk://#diff-46c9e78bbd2291e71a552cd350a11a470b812ef8f8d5e1c932fd9a446b3dd07aR186-R191) [[2]](diffhunk://#diff-46c9e78bbd2291e71a552cd350a11a470b812ef8f8d5e1c932fd9a446b3dd07aR2)

**Workflow and reviewer logic enhancements:**

* Included the `TIMEOUT` status in the set of terminal workflow run statuses to ensure correct handling of timed-out runs.
* Updated the ordering logic for workflow runs in `AiReviewerDecisionMakerService` to sort by `startedAt` and `completedAt` in descending order, placing nulls last for more consistent data retrieval.