### PR TITLE
Hide final score

### DIFF
--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -4636,10 +4636,7 @@ export class SubmissionService {
         continue;
       }
 
-      const shouldStrip =
-        roleSummary.hasSubmitter &&
-        !roleSummary.hasCopilot &&
-        !roleSummary.hasReviewer;
+      const shouldStrip = !roleSummary.hasCopilot && !roleSummary.hasReviewer;
       if (!shouldStrip) {
         continue;
       }

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -4983,11 +4983,7 @@ export class SubmissionService {
       const roleSummary =
         visibilityContext.roleSummaryByChallenge.get(challengeId) ??
         EMPTY_ROLE_SUMMARY;
-      if (
-        !roleSummary.hasSubmitter ||
-        roleSummary.hasCopilot ||
-        roleSummary.hasReviewer
-      ) {
+      if (roleSummary.hasCopilot || roleSummary.hasReviewer) {
         continue;
       }
 
@@ -5018,6 +5014,11 @@ export class SubmissionService {
       }
 
       delete (submission as any).id;
+      delete (submission as any).initialScore;
+      delete (submission as any).finalScore;
+      delete (submission as any).aiDecisionScore;
+      delete (submission as any).aiDecisionStatus;
+
       if (Object.prototype.hasOwnProperty.call(submission, 'reviewSummation')) {
         delete (submission as any).reviewSummation;
       }


### PR DESCRIPTION
This pull request updates the `SubmissionService` to refine how submission data is filtered and sanitized before being returned, particularly focusing on role-based visibility and sensitive field removal.

**Role-based filtering changes:**

* Adjusted the logic determining when to strip submitter information: now, submissions are stripped if the user is not a copilot or reviewer, regardless of submitter status.
* Updated the condition for skipping submissions: now, only users with copilot or reviewer roles will see certain submissions, simplifying the previous logic.

**Sensitive field removal:**

* Enhanced data sanitization by deleting additional sensitive fields (`initialScore`, `finalScore`, `aiDecisionScore`, `aiDecisionStatus`) from submissions before returning them.