### PR TITLE
Fixes for score visibility in MMs and challenges

### DIFF
--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -4986,20 +4986,20 @@ export class SubmissionService {
       const roleSummary =
         visibilityContext.roleSummaryByChallenge.get(challengeId) ??
         EMPTY_ROLE_SUMMARY;
-      if (roleSummary.hasCopilot) {
+      const challenge = visibilityContext.challengeDetailsById.get(challengeId);
+
+      if (roleSummary.hasCopilot || this.isMarathonMatchChallenge(challenge)) {
         continue;
       }
 
-      const challenge = visibilityContext.challengeDetailsById.get(challengeId);
       const isActiveChallenge =
         !challenge || challenge.status === ChallengeStatus.ACTIVE;
       if (!isActiveChallenge) {
         continue;
       }
 
-      if (!this.isMarathonMatchChallenge(challenge)) {
-        delete (submission as any).id;
-      }
+      // reviewer shouldn't be able to identify a submission by id
+      delete (submission as any).id;
 
       if (roleSummary.hasReviewer) {
         return;
@@ -5024,12 +5024,10 @@ export class SubmissionService {
         }
       }
 
-      if (!this.isMarathonMatchChallenge(challenge)) {
-        delete (submission as any).initialScore;
-        delete (submission as any).finalScore;
-        delete (submission as any).aiDecisionScore;
-        delete (submission as any).aiDecisionStatus;
-      }
+      delete (submission as any).initialScore;
+      delete (submission as any).finalScore;
+      delete (submission as any).aiDecisionScore;
+      delete (submission as any).aiDecisionStatus;
 
       if (Object.prototype.hasOwnProperty.call(submission, 'reviewSummation')) {
         delete (submission as any).reviewSummation;


### PR DESCRIPTION
This pull request updates the logic for handling submissions in the `SubmissionService` to better account for marathon match challenges and to improve data privacy for reviewers. The main changes focus on when to exclude certain submission properties based on challenge type and user role.

Logic improvements for marathon match challenges and reviewer privacy:

* Updated the condition to skip processing for challenges that either have a copilot or are marathon match challenges, ensuring marathon matches are handled consistently with other special cases.
* Removed unnecessary conditional checks before deleting sensitive properties (`initialScore`, `finalScore`, `aiDecisionScore`, `aiDecisionStatus`) from the submission object, ensuring these fields are always removed regardless of challenge type.