### PR TITLE
[PROD HOTFIX] Allow cancelled events to be persisted to db even for dump workflow step

### DIFF
--- a/src/shared/modules/global/workflow-queue.handler.ts
+++ b/src/shared/modules/global/workflow-queue.handler.ts
@@ -510,7 +510,6 @@ export class WorkflowQueueHandler {
 
     const aiWorkflowRuns = await this.prisma.aiWorkflowRun.findMany({
       where: {
-        status: { in: ['DISPATCHED', 'IN_PROGRESS'] },
         gitRunId: `${event.workflow_job.run_id}`,
       },
       include: {
@@ -520,7 +519,7 @@ export class WorkflowQueueHandler {
 
     if (aiWorkflowRuns.length > 1) {
       this.logger.error(
-        `ERROR! There are more than 1 workflow runs in DISPATCHED status and workflow.gitWorkflowId=${event.workflow_job.name}!`,
+        `ERROR! There are more than 1 workflow runs for workflow=${event.workflow_job.name} and gitWorkflowId=${event.workflow_job.run_id}!`,
       );
       return;
     }
@@ -530,14 +529,19 @@ export class WorkflowQueueHandler {
 
     if (
       aiWorkflowRun &&
-      !['DISPATCHED', 'IN_PROGRESS'].includes(aiWorkflowRun.status)
+      !['INIT', 'DISPATCHED', 'IN_PROGRESS'].includes(aiWorkflowRun.status)
     ) {
       const errorMessage = `Unexpected aiWorkflowRun status '${aiWorkflowRun.status}' for gitRunId=${event.workflow_job.run_id} and workflowJobName=${event.workflow_job.name}`;
       this.logger.error(errorMessage);
       return;
     }
 
-    if (event.workflow_job.name === 'dump-workflow-context') {
+    const conclusion = event.workflow_job.conclusion?.toUpperCase();
+    const terminalStatus = this.normalizeWorkflowConclusion(conclusion);
+    if (
+      event.workflow_job.name === 'dump-workflow-context' &&
+      terminalStatus !== 'CANCELLED'
+    ) {
       this.logger.log(
         `Ignoring dump-workflow-context job event for run ${event.workflow_job.run_id}`,
       );
@@ -555,7 +559,6 @@ export class WorkflowQueueHandler {
       return;
     }
 
-    const conclusion = event.workflow_job.conclusion?.toUpperCase();
     switch (event.action) {
       case 'in_progress':
         if (aiWorkflowRun.status !== 'DISPATCHED') {
@@ -579,7 +582,6 @@ export class WorkflowQueueHandler {
         });
         break;
       case 'completed': {
-        const terminalStatus = this.normalizeWorkflowConclusion(conclusion);
         const didRetry =
           ['FAILURE', 'TIMEOUT'].includes(terminalStatus) &&
           (await this.retryWorkflowRunIfEligible(


### PR DESCRIPTION
This pull request refines the workflow job event handling logic in `workflow-queue.handler.ts`. The most significant updates include expanding the set of valid workflow run statuses, improving error messages, and ensuring that certain workflow jobs are ignored only under specific terminal conditions.

**Workflow status handling improvements:**

* Expanded the list of valid statuses for `aiWorkflowRun` to include `'INIT'` in addition to `'DISPATCHED'` and `'IN_PROGRESS'`, preventing errors for runs in the initial state.
* Adjusted the query for `aiWorkflowRun` to no longer filter by status, ensuring all runs for a given `gitRunId` are considered.

**Error handling and logging enhancements:**

* Improved the error message when multiple workflow runs are found, now including both the workflow name and `run_id` for better traceability.

**Conditional workflow job event handling:**

* Updated logic to ignore `dump-workflow-context` workflow job events only if their terminal status is not `'CANCELLED'`, preventing unnecessary log entries for cancelled jobs.

**Code cleanup:**

* Moved the definition of `conclusion` and `terminalStatus` to ensure they are available before use and removed redundant code. [[1]](diffhunk://#diff-eb631a859275d8a6e6e15a05d5188e9ae169b75a41bdaca3831c10237165977cL558) [[2]](diffhunk://#diff-eb631a859275d8a6e6e15a05d5188e9ae169b75a41bdaca3831c10237165977cL582)