### PR TITLE
PM-5231: Allow Marathon validation upload scopes

### DIFF
--- a/src/api/submission/submission.controller.spec.ts
+++ b/src/api/submission/submission.controller.spec.ts
@@ -1,0 +1,27 @@
+jest.mock('nanoid', () => ({
+  __esModule: true,
+  nanoid: () => 'mock-nanoid',
+}));
+
+import { SCOPES_KEY } from 'src/shared/decorators/scopes.decorator';
+import { Scope } from 'src/shared/enums/scopes.enum';
+import { SubmissionController } from './submission.controller';
+
+describe('SubmissionController', () => {
+  it('allows Marathon Match service scopes on validation upload', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      SubmissionController.prototype,
+      'validationUploadSubmission',
+    );
+    const scopes = Reflect.getMetadata(SCOPES_KEY, descriptor?.value as object);
+
+    expect(descriptor?.value).toBeDefined();
+    expect(scopes).toEqual(
+      expect.arrayContaining([
+        Scope.CreateSubmission,
+        Scope.UpdateMarathonMatch,
+        Scope.AllMarathonMatch,
+      ]),
+    );
+  });
+});

--- a/src/api/submission/submission.controller.ts
+++ b/src/api/submission/submission.controller.ts
@@ -195,11 +195,15 @@ export class SubmissionController {
 
   @Post('/validation-upload')
   @Roles(UserRole.Admin)
-  @Scopes(Scope.CreateSubmission)
+  @Scopes(
+    Scope.CreateSubmission,
+    Scope.UpdateMarathonMatch,
+    Scope.AllMarathonMatch,
+  )
   @ApiOperation({
     summary: 'Upload and create a clean validation submission as Admin/M2M',
     description:
-      'Roles: Admin (M2M allowed via scope). Uploads file contents directly to clean submission storage and creates a downloadable submission row without phase, submitter, counter, scan, or notification side effects. Intended for Marathon Match scorer validation before challenge launch. | Scopes: create:submission',
+      'Roles: Admin (M2M allowed via create:submission, update:marathon-match, or all:marathon-match scope). Uploads file contents directly to clean submission storage and creates a downloadable submission row without phase, submitter, counter, scan, or notification side effects. Intended for Marathon Match scorer validation before challenge launch.',
   })
   @ApiResponse({
     status: 201,

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -403,7 +403,7 @@ export class SubmissionService {
   /**
    * Creates a clean, downloadable submission row for scorer validation without
    * normal submission lifecycle side effects.
-   * @param authUser Authenticated admin or M2M token with create:submission access.
+   * @param authUser Authenticated admin or M2M caller authorized by the validation-upload route scopes.
    * @param body Validation upload metadata containing challenge, member, and submission type.
    * @param file Uploaded submission artifact.
    * @returns Created validation submission response.

--- a/src/shared/enums/scopes.enum.ts
+++ b/src/shared/enums/scopes.enum.ts
@@ -70,6 +70,10 @@ export enum Scope {
   DeleteSubmissionArtifacts = 'delete:submission-artifacts',
   AllSubmissionArtifacts = 'all:submission-artifacts',
 
+  // Marathon Match scopes used by service-to-service validation flows
+  UpdateMarathonMatch = 'update:marathon-match',
+  AllMarathonMatch = 'all:marathon-match',
+
   // AI workflow scopes
   CreateWorkflow = 'create:workflow',
   ReadWorkflow = 'read:workflow',
@@ -151,4 +155,5 @@ export const ALL_SCOPE_MAPPINGS: Record<string, string[]> = {
     Scope.ReadSubmissionArtifacts,
     Scope.DeleteSubmissionArtifacts,
   ],
+  [Scope.AllMarathonMatch]: [Scope.UpdateMarathonMatch],
 };


### PR DESCRIPTION
What was broken

QA reported that uploading a Marathon Match scorer validation submission from Work returned a 500 instead of queuing the validation scoring run.

Root cause

The previous PM-5231 implementation added Review API clean validation uploads, but the endpoint only accepted create:submission scoped M2M tokens. The Marathon Match API service token used for scorer operations is authorized with Marathon Match scopes, so Review API rejected the internal validation-upload call before the clean submission could be created.

What was changed

Added Review API Marathon Match update/all scopes and allowed them on POST /submissions/validation-upload while preserving the existing create:submission access. Updated the validation-upload docs to describe the accepted scopes.

Any added/updated tests

Added a SubmissionController metadata test that verifies validation-upload accepts create:submission, update:marathon-match, and all:marathon-match scopes.

Validation run:
- pnpm test -- submission.controller.spec.ts passed
- pnpm lint passed
- pnpm build passed
- pnpm test still fails in pre-existing SubmissionService listSubmission privacy assertions unrelated to this PM-5231 route-scope change
