### PR TITLE
PM-5365 - Allow creating review context

### DIFF
--- a/src/api/challenge-review-context/challenge-review-context.controller.ts
+++ b/src/api/challenge-review-context/challenge-review-context.controller.ts
@@ -42,7 +42,7 @@ export class ChallengeReviewContextController {
   @ApiOperation({
     summary: 'Create a challenge review context',
     description:
-      'Roles: Admin, Copilot | Scopes: create:challenge-review-context. Only allowed for challenges in DRAFT status or REGISTRATION phase. At most one context per challenge.',
+      'Roles: Admin, Copilot | Scopes: create:challenge-review-context. Allowed for any existing challenge. At most one context per challenge.',
   })
   @ApiBody({
     description: 'Challenge review context to create',

--- a/src/api/challenge-review-context/challenge-review-context.service.spec.ts
+++ b/src/api/challenge-review-context/challenge-review-context.service.spec.ts
@@ -1,0 +1,152 @@
+jest.mock('../../shared/modules/global/prisma.service', () => ({
+  PrismaService: class PrismaServiceMock {},
+}));
+
+import { ForbiddenException } from '@nestjs/common';
+import { ChallengeReviewContextService } from './challenge-review-context.service';
+import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
+import type { JwtUser } from 'src/shared/modules/global/jwt.service';
+import {
+  CreateChallengeReviewContextDto,
+  UpdateChallengeReviewContextDto,
+  ChallengeReviewContextStatus,
+} from '../../dto/challengeReviewContext.dto';
+
+describe('ChallengeReviewContextService', () => {
+  const challengeApiMock = {
+    getChallengeDetailForUser: jest.fn(),
+  };
+
+  const prismaMock = {
+    challengeReviewContext: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  let service: ChallengeReviewContextService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new ChallengeReviewContextService(
+      prismaMock as any,
+      challengeApiMock as any,
+    );
+  });
+
+  const authUser: JwtUser = { userId: 'user-1', isMachine: false };
+
+  it('allows creating a review context for any existing challenge', async () => {
+    const challenge = {
+      id: 'challenge-1',
+      status: ChallengeStatus.COMPLETED,
+      phases: [],
+    };
+    challengeApiMock.getChallengeDetailForUser.mockResolvedValue(challenge);
+    prismaMock.challengeReviewContext.findUnique.mockResolvedValue(null);
+    prismaMock.challengeReviewContext.create.mockResolvedValue({
+      id: 'context-1',
+      challengeId: 'challenge-1',
+      context: { summary: 'review context' },
+      status: ChallengeReviewContextStatus.AI_GENERATED,
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      createdBy: 'user-1',
+      updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+      updatedBy: 'user-1',
+    });
+
+    const dto: CreateChallengeReviewContextDto = {
+      challengeId: 'challenge-1',
+      context: { summary: 'review context' },
+      status: ChallengeReviewContextStatus.AI_GENERATED,
+    };
+
+    const result = await service.create(dto, authUser);
+
+    expect(result.challengeId).toBe('challenge-1');
+    expect(prismaMock.challengeReviewContext.create).toHaveBeenCalledWith({
+      data: {
+        challengeId: 'challenge-1',
+        context: dto.context,
+        status: dto.status,
+        createdBy: authUser.userId?.toString(),
+        updatedBy: authUser.userId?.toString(),
+      },
+    });
+  });
+
+  it('forbids updating a review context when challenge is not DRAFT and has no open registration phase', async () => {
+    const challenge = {
+      id: 'challenge-2',
+      status: ChallengeStatus.COMPLETED,
+      phases: [{ id: 'phase-1', name: 'Submission', isOpen: false }],
+    };
+    challengeApiMock.getChallengeDetailForUser.mockResolvedValue(challenge);
+    prismaMock.challengeReviewContext.findUnique.mockResolvedValue({
+      id: 'context-2',
+      challengeId: 'challenge-2',
+      context: { summary: 'existing' },
+      status: ChallengeReviewContextStatus.HUMAN_APPROVED,
+      createdAt: new Date(),
+      createdBy: 'user-1',
+      updatedAt: new Date(),
+      updatedBy: 'user-1',
+    });
+
+    const dto: UpdateChallengeReviewContextDto = {
+      context: { summary: 'updated context' },
+    };
+
+    await expect(service.update('challenge-2', dto, authUser)).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(prismaMock.challengeReviewContext.update).not.toHaveBeenCalled();
+  });
+
+  it('allows updating a review context when challenge has an open registration phase', async () => {
+    const challenge = {
+      id: 'challenge-3',
+      status: ChallengeStatus.ACTIVE,
+      phases: [{ id: 'phase-2', name: 'Registration', isOpen: true }],
+    };
+    challengeApiMock.getChallengeDetailForUser.mockResolvedValue(challenge);
+    prismaMock.challengeReviewContext.findUnique.mockResolvedValue({
+      id: 'context-3',
+      challengeId: 'challenge-3',
+      context: { summary: 'existing' },
+      status: ChallengeReviewContextStatus.HUMAN_APPROVED,
+      createdAt: new Date(),
+      createdBy: 'user-1',
+      updatedAt: new Date(),
+      updatedBy: 'user-1',
+    });
+    prismaMock.challengeReviewContext.update.mockResolvedValue({
+      id: 'context-3',
+      challengeId: 'challenge-3',
+      context: { summary: 'updated context' },
+      status: ChallengeReviewContextStatus.HUMAN_APPROVED,
+      createdAt: new Date(),
+      createdBy: 'user-1',
+      updatedAt: new Date(),
+      updatedBy: 'user-1',
+    });
+
+    const dto: UpdateChallengeReviewContextDto = {
+      context: { summary: 'updated context' },
+      status: ChallengeReviewContextStatus.HUMAN_APPROVED,
+    };
+
+    const result = await service.update('challenge-3', dto, authUser);
+
+    expect(result.context).toEqual({ summary: 'updated context' });
+    expect(prismaMock.challengeReviewContext.update).toHaveBeenCalledWith({
+      where: { challengeId: 'challenge-3' },
+      data: {
+        context: dto.context,
+        status: dto.status,
+        updatedBy: authUser.userId?.toString(),
+      },
+    });
+  });
+});

--- a/src/api/challenge-review-context/challenge-review-context.service.spec.ts
+++ b/src/api/challenge-review-context/challenge-review-context.service.spec.ts
@@ -149,4 +149,47 @@ describe('ChallengeReviewContextService', () => {
       },
     });
   });
+
+  it('allows updating a review context when challenge is in DRAFT status', async () => {
+    const challenge = {
+      id: 'challenge-4',
+      status: ChallengeStatus.DRAFT,
+      phases: [],
+    };
+    challengeApiMock.getChallengeDetailForUser.mockResolvedValue(challenge);
+    prismaMock.challengeReviewContext.findUnique.mockResolvedValue({
+      id: 'context-4',
+      challengeId: 'challenge-4',
+      context: { summary: 'existing' },
+      status: ChallengeReviewContextStatus.AI_GENERATED,
+      createdAt: new Date(),
+      createdBy: 'user-1',
+      updatedAt: new Date(),
+      updatedBy: 'user-1',
+    });
+    prismaMock.challengeReviewContext.update.mockResolvedValue({
+      id: 'context-4',
+      challengeId: 'challenge-4',
+      context: { summary: 'updated context' },
+      status: ChallengeReviewContextStatus.HUMAN_APPROVED,
+      createdAt: new Date(),
+      createdBy: 'user-1',
+      updatedAt: new Date(),
+      updatedBy: 'user-1',
+    });
+    const dto: UpdateChallengeReviewContextDto = {
+      context: { summary: 'updated context' },
+      status: ChallengeReviewContextStatus.HUMAN_APPROVED,
+    };
+    const result = await service.update('challenge-4', dto, authUser);
+    expect(result.context).toEqual({ summary: 'updated context' });
+    expect(prismaMock.challengeReviewContext.update).toHaveBeenCalledWith({
+      where: { challengeId: 'challenge-4' },
+      data: {
+        context: dto.context,
+        status: dto.status,
+        updatedBy: authUser.userId?.toString(),
+      },
+    });
+  });
 });

--- a/src/api/challenge-review-context/challenge-review-context.service.ts
+++ b/src/api/challenge-review-context/challenge-review-context.service.ts
@@ -92,7 +92,7 @@ export class ChallengeReviewContextService {
    * @throws ForbiddenException when whitelist or challenge phase rules block writing.
    * @throws NotFoundException when the challenge cannot be loaded.
    */
-  private async validateChallengeAllowedForWrite(
+  private async validateChallengeAllowedForUpdate(
     challengeId: string,
     authUser: JwtUser,
     loadedChallenge?: ChallengeData,
@@ -107,7 +107,7 @@ export class ChallengeReviewContextService {
       ) ?? false;
     if (!isDraft && !hasRegistrationPhase) {
       throw new ForbiddenException(
-        'Creating or updating challenge review context is only allowed for challenges in DRAFT status or REGISTRATION phase.',
+        'Updating challenge review context is only allowed for challenges in DRAFT status or REGISTRATION phase.',
       );
     }
   }
@@ -116,15 +116,7 @@ export class ChallengeReviewContextService {
     dto: CreateChallengeReviewContextDto,
     authUser: JwtUser,
   ): Promise<ChallengeReviewContextResponseDto> {
-    const challenge = await this.validateChallengeExists(
-      dto.challengeId,
-      authUser,
-    );
-    await this.validateChallengeAllowedForWrite(
-      dto.challengeId,
-      authUser,
-      challenge,
-    );
+    await this.validateChallengeExists(dto.challengeId, authUser);
 
     const existing = await this.prisma.challengeReviewContext.findUnique({
       where: { challengeId: dto.challengeId },
@@ -173,7 +165,7 @@ export class ChallengeReviewContextService {
     authUser: JwtUser,
   ): Promise<ChallengeReviewContextResponseDto> {
     const challenge = await this.validateChallengeExists(challengeId, authUser);
-    await this.validateChallengeAllowedForWrite(
+    await this.validateChallengeAllowedForUpdate(
       challengeId,
       authUser,
       challenge,


### PR DESCRIPTION
This pull request updates the logic and documentation for creating and updating challenge review contexts. The most significant change is that creating a review context is now allowed for any existing challenge, regardless of its status, while updating a review context is still restricted to challenges in DRAFT status or with an open REGISTRATION phase. Additionally, comprehensive unit tests have been added for these behaviors.

**Policy and Documentation Updates**
* The `create` endpoint's documentation in `ChallengeReviewContextController` was updated to state that creating a review context is now allowed for any existing challenge, not just those in DRAFT or REGISTRATION phase.
* The error message in the update validation now clarifies that only updating (not creating) is restricted to DRAFT or REGISTRATION phase challenges.

**Service Logic Changes**
* The `create` method in `ChallengeReviewContextService` no longer checks for DRAFT/REGISTRATION phase, only that the challenge exists.
* The method for validating write permissions was renamed and refactored to `validateChallengeAllowedForUpdate`, and is now only used for updates. [[1]](diffhunk://#diff-21455d058a297c7e6981042a972084483dfef96f9e7ac43f66ffafe452abd782L95-R95) [[2]](diffhunk://#diff-21455d058a297c7e6981042a972084483dfef96f9e7ac43f66ffafe452abd782L176-R168)

**Testing**
* Added comprehensive unit tests for `ChallengeReviewContextService` to verify the new creation permissions and update restrictions.