### PR TITLE
PM-4011 - check reviewer role

### DIFF
--- a/src/api/appeal/appeal.service.ts
+++ b/src/api/appeal/appeal.service.ts
@@ -682,29 +682,22 @@ export class AppealService {
         challengeId,
       );
 
-      const data = await this.prisma.appeal.update({
-        where: { id: appealId },
+      const data = await this.prisma.appealResponse.create({
         data: {
-          appealResponse: {
-            create: {
-              ...mapAppealResponseRequestToDto(body),
-              resourceId: reviewerResourceId,
-            },
-          },
-        },
-        include: {
-          appealResponse: true,
+          appealId,
+          ...mapAppealResponseRequestToDto(body),
+          resourceId: reviewerResourceId,
         },
       });
 
       this.logger.log(`Appeal response created for appeal ID: ${appealId}`);
       await this.publishAppealRespondedEvent({
         appealId,
-        appealResponseId: data.appealResponse?.id ?? null,
+        appealResponseId: data.id,
         reviewId: review.id,
         reviewerResource,
       });
-      return data.appealResponse as AppealResponseResponseDto;
+      return data as AppealResponseResponseDto;
     } catch (error) {
       if (error instanceof ForbiddenException) {
         throw error;

--- a/src/api/review/review.service.spec.ts
+++ b/src/api/review/review.service.spec.ts
@@ -3667,6 +3667,43 @@ describe('ReviewService.updateReviewItem validations', () => {
     expect(prismaMock.reviewItem.update).not.toHaveBeenCalled();
   });
 
+  it('allows admins assigned as reviewers on the challenge to update review item scores without a manager comment', async () => {
+    const adminReviewerUser: JwtUser = {
+      userId: 'admin-reviewer-1',
+      roles: [UserRole.Admin],
+      isMachine: false,
+    };
+
+    resourceApiServiceMock.getMemberResourcesRoles.mockResolvedValueOnce([
+      {
+        id: 'resource-1',
+        memberId: 'admin-reviewer-1',
+        roleName: 'Reviewer',
+        challengeId: 'challenge-1',
+      },
+    ]);
+
+    prismaMock.reviewItem.update.mockResolvedValueOnce({
+      ...baseExistingItem,
+      finalAnswer: 'No',
+      managerComment: null,
+      reviewItemComments: [],
+    });
+
+    await expect(
+      service.updateReviewItem(adminReviewerUser, 'item-1', {
+        ...baseRequest,
+        finalAnswer: 'No',
+      }),
+    ).resolves.toMatchObject({ id: 'item-1' });
+
+    expect(resourceApiServiceMock.getMemberResourcesRoles).toHaveBeenCalledWith(
+      'challenge-1',
+      'admin-reviewer-1',
+    );
+    expect(prismaMock.reviewItem.update).toHaveBeenCalled();
+  });
+
   it('requires manager comment when an admin updates the score on a review item', async () => {
     const adminUser: JwtUser = {
       userId: 'admin-1',
@@ -3674,6 +3711,7 @@ describe('ReviewService.updateReviewItem validations', () => {
       isMachine: false,
     };
 
+    resourceApiServiceMock.getMemberResourcesRoles.mockResolvedValueOnce([]);
     prismaMock.reviewItem.update.mockClear();
     prismaMock.reviewAudit.create.mockClear();
 
@@ -3689,9 +3727,10 @@ describe('ReviewService.updateReviewItem validations', () => {
       status: 400,
     });
 
-    expect(
-      resourceApiServiceMock.getMemberResourcesRoles,
-    ).not.toHaveBeenCalled();
+    expect(resourceApiServiceMock.getMemberResourcesRoles).toHaveBeenCalledWith(
+      'challenge-1',
+      'admin-1',
+    );
     expect(prismaMock.reviewItem.update).not.toHaveBeenCalled();
     expect(prismaMock.reviewAudit.create).not.toHaveBeenCalled();
   });

--- a/src/api/review/review.service.ts
+++ b/src/api/review/review.service.ts
@@ -799,6 +799,8 @@ export class ReviewService {
 
     await this.ensureChallengeWhitelistAccess(requester, challengeId);
 
+    const isRequesterAdmin = isAdmin(requester);
+
     if (requester.isMachine) {
       return {
         mode: 'machine',
@@ -806,17 +808,6 @@ export class ReviewService {
         hasCopilotRole: false,
         ownsReview: false,
         requiresManagerComment: false,
-        requesterResources: [],
-      };
-    }
-
-    if (isAdmin(requester)) {
-      return {
-        mode: 'admin',
-        hasReviewerRole: false,
-        hasCopilotRole: false,
-        ownsReview: false,
-        requiresManagerComment: true,
         requesterResources: [],
       };
     }
@@ -840,7 +831,7 @@ export class ReviewService {
           ? 'delete'
           : 'update';
 
-    if (!hasReviewerRole && !hasCopilotRole) {
+    if (!hasReviewerRole && !hasCopilotRole && !isRequesterAdmin) {
       throw new ForbiddenException({
         message: `You do not have permission to ${actionVerb} this review item.`,
         code: `REVIEW_ITEM_${context.action.toUpperCase()}_FORBIDDEN_ROLE`,
@@ -887,6 +878,38 @@ export class ReviewService {
           itemId: context.itemId,
           challengeId,
           requester: requesterMemberId,
+        },
+      });
+    }
+
+    if (isRequesterAdmin) {
+      const isAssignedReviewerRole = requesterResources.some((resource) => {
+        const normalizedRoleName = (resource.roleName || '').toLowerCase();
+        const matchesReviewer = normalizedRoleName.includes('reviewer');
+        const matchesChallenge = challengeId
+          ? resource.challengeId === challengeId
+          : false;
+        return matchesReviewer && matchesChallenge;
+      });
+
+      return {
+        mode: 'admin',
+        hasReviewerRole,
+        hasCopilotRole,
+        ownsReview: false,
+        requiresManagerComment: !isAssignedReviewerRole,
+        requesterResources,
+      };
+    }
+
+    if (!hasReviewerRole && !hasCopilotRole) {
+      throw new ForbiddenException({
+        message: `You do not have permission to ${actionVerb} this review item.`,
+        code: `REVIEW_ITEM_${context.action.toUpperCase()}_FORBIDDEN_ROLE`,
+        details: {
+          reviewId: review.id,
+          itemId: context.itemId,
+          requesterRoles: requester.roles,
         },
       });
     }


### PR DESCRIPTION
Updated the `ReviewService` logic so that admins assigned as reviewers on a challenge can update review item scores without a manager comment, while other admins still require a manager comment. 