### PR TITLE
PM-5417 - fix creation of appeal response - use direct appealResponse.create

### DIFF
--- a/src/api/appeal/appeal.service.ts
+++ b/src/api/appeal/appeal.service.ts
@@ -682,29 +682,22 @@ export class AppealService {
         challengeId,
       );
 
-      const data = await this.prisma.appeal.update({
-        where: { id: appealId },
+      const data = await this.prisma.appealResponse.create({
         data: {
-          appealResponse: {
-            create: {
-              ...mapAppealResponseRequestToDto(body),
-              resourceId: reviewerResourceId,
-            },
-          },
-        },
-        include: {
-          appealResponse: true,
+          appealId,
+          ...mapAppealResponseRequestToDto(body),
+          resourceId: reviewerResourceId,
         },
       });
 
       this.logger.log(`Appeal response created for appeal ID: ${appealId}`);
       await this.publishAppealRespondedEvent({
         appealId,
-        appealResponseId: data.appealResponse?.id ?? null,
+        appealResponseId: data.id,
         reviewId: review.id,
         reviewerResource,
       });
-      return data.appealResponse as AppealResponseResponseDto;
+      return data as AppealResponseResponseDto;
     } catch (error) {
       if (error instanceof ForbiddenException) {
         throw error;


### PR DESCRIPTION
This pull request refactors how appeal responses are created and returned in the `AppealService`. Instead of updating an existing appeal with a nested appeal response, the code now directly creates a new `appealResponse` record and simplifies the return value and event publishing logic.

**Refactor of appeal response creation:**

* Changed the service to use `prisma.appealResponse.create` directly, rather than updating the `appeal` record with a nested create, simplifying the data flow and making the intent clearer.
* Updated event publishing and return logic to use the newly created `appealResponse`'s ID and data directly, improving clarity and reducing unnecessary nesting.