### PR TITLE
PM-5559: Publish F2F URL submission events

### DIFF
--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -816,6 +816,177 @@ describe('SubmissionService', () => {
     });
   });
 
+  describe('createSubmission URL First2Finish event', () => {
+    let prismaMock: {
+      submission: {
+        create: jest.Mock;
+      };
+    };
+    let prismaErrorServiceMock: { handleError: jest.Mock };
+    let challengeApiServiceMock: {
+      validateChallengeExists: jest.Mock;
+      validateSubmissionCreation: jest.Mock;
+      validateCheckpointSubmissionCreation: jest.Mock;
+      validateFinalFixSubmissionCreation: jest.Mock;
+      getChallengeDetail: jest.Mock;
+    };
+    let resourceApiServiceMock: {
+      validateSubmitterRegistration: jest.Mock;
+    };
+    let resourcePrismaMock: {
+      resource: {
+        findFirst: jest.Mock;
+      };
+    };
+    let eventBusServiceMock: {
+      publish: jest.Mock;
+    };
+    let challengeCatalogServiceMock: {
+      ensureSubmissionTypeAllowed: jest.Mock;
+    };
+    let challengePrismaMock: {
+      $executeRaw: jest.Mock;
+      $queryRaw: jest.Mock;
+    };
+    let createService: SubmissionService;
+
+    const createdSubmission = {
+      challengeId: 'challenge-f2f',
+      createdAt: new Date('2026-07-10T13:00:00Z'),
+      createdBy: '1001',
+      eventRaised: false,
+      fileType: undefined,
+      id: 'submission-f2f-url',
+      isFileSubmission: false,
+      legacyChallengeId: null,
+      legacySubmissionId: null,
+      legacyUploadId: null,
+      memberId: '1001',
+      prizeId: null,
+      status: SubmissionStatus.ACTIVE,
+      submissionPhaseId: 'submission-phase',
+      submittedDate: new Date('2026-07-10T13:00:00Z'),
+      systemFileName: 'submission',
+      type: SubmissionType.CONTEST_SUBMISSION,
+      updatedAt: new Date('2026-07-10T13:00:00Z'),
+      updatedBy: '1001',
+      url: 'https://example.com/submission',
+      virusScan: false,
+      viewCount: 0,
+    };
+
+    beforeEach(() => {
+      prismaMock = {
+        submission: {
+          create: jest.fn().mockResolvedValue(createdSubmission),
+        },
+      };
+      prismaErrorServiceMock = {
+        handleError: jest.fn().mockReturnValue({
+          message: 'Unexpected error',
+          code: 'INTERNAL_ERROR',
+          details: {},
+        }),
+      };
+      challengeApiServiceMock = {
+        validateChallengeExists: jest.fn().mockResolvedValue({
+          id: 'challenge-f2f',
+          legacy: {},
+          status: ChallengeStatus.ACTIVE,
+          track: 'Development',
+          type: 'First2Finish',
+        }),
+        validateSubmissionCreation: jest.fn().mockResolvedValue(undefined),
+        validateCheckpointSubmissionCreation: jest
+          .fn()
+          .mockResolvedValue(undefined),
+        validateFinalFixSubmissionCreation: jest
+          .fn()
+          .mockResolvedValue(undefined),
+        getChallengeDetail: jest.fn().mockResolvedValue({
+          id: 'challenge-f2f',
+          type: 'First2Finish',
+        }),
+      };
+      resourceApiServiceMock = {
+        validateSubmitterRegistration: jest.fn().mockResolvedValue(undefined),
+      };
+      resourcePrismaMock = {
+        resource: {
+          findFirst: jest.fn().mockResolvedValue({
+            memberHandle: 'submitterHandle',
+          }),
+        },
+      };
+      eventBusServiceMock = {
+        publish: jest.fn().mockResolvedValue(undefined),
+      };
+      challengeCatalogServiceMock = {
+        ensureSubmissionTypeAllowed: jest.fn(),
+      };
+      challengePrismaMock = {
+        $executeRaw: jest.fn().mockResolvedValue(1),
+        $queryRaw: jest.fn().mockResolvedValue([]),
+      };
+
+      createService = new SubmissionService(
+        prismaMock as any,
+        prismaErrorServiceMock as any,
+        challengePrismaMock as any,
+        challengeApiServiceMock as any,
+        resourceApiServiceMock as any,
+        resourcePrismaMock as any,
+        eventBusServiceMock as any,
+        challengeCatalogServiceMock as any,
+        {} as any,
+      );
+
+      jest
+        .spyOn(createService as any, 'publishSubmissionCreateEvent')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(createService as any, 'publishSubmissionScanEvent')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(createService as any, 'populateLatestSubmissionFlags')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(createService as any, 'stripIsLatestForUnlimitedChallenges')
+        .mockResolvedValue(undefined);
+    });
+
+    it('publishes first2finish.submission.received immediately for URL submissions', async () => {
+      await createService.createSubmission(
+        {
+          isMachine: false,
+          roles: [],
+          userId: '1001',
+        } as any,
+        {
+          challengeId: 'challenge-f2f',
+          memberId: '1001',
+          type: SubmissionType.CONTEST_SUBMISSION,
+          url: 'https://example.com/submission',
+        },
+      );
+
+      expect(
+        (createService as any).publishSubmissionScanEvent,
+      ).not.toHaveBeenCalled();
+      expect(eventBusServiceMock.publish).toHaveBeenCalledWith(
+        'first2finish.submission.received',
+        {
+          challengeId: 'challenge-f2f',
+          memberHandle: 'submitterHandle',
+          memberId: '1001',
+          submissionId: 'submission-f2f-url',
+          submissionUrl: 'https://example.com/submission',
+          submittedDate: '2026-07-10T13:00:00.000Z',
+        },
+      );
+    });
+  });
+
   describe('createSubmission Final Fix', () => {
     let prismaMock: {
       submission: {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -123,7 +123,7 @@ export type SubmissionScanRetryResult = {
   failed: number;
 };
 
-interface TopgearSubmissionEventPayload {
+interface RapidSubmissionEventPayload {
   submissionId: string;
   challengeId: string;
   submissionUrl: string;
@@ -132,7 +132,7 @@ interface TopgearSubmissionEventPayload {
   submittedDate: string;
 }
 
-type TopgearSubmissionRecord = {
+type RapidSubmissionRecord = {
   id: string;
   challengeId: string | null;
   memberId: string | null;
@@ -2709,8 +2709,95 @@ export class SubmissionService {
     );
   }
 
+  /**
+   * Publishes the First2Finish submission event immediately for URL submissions.
+   *
+   * File-backed submissions publish the same event after AV scan completes. URL
+   * submissions skip AV scan, so this method keeps the autopilot iterative
+   * review flow aligned for non-file First2Finish submissions.
+   *
+   * @param submission - Newly created non-file submission details.
+   * @returns Resolves after the event is published or skipped for non-F2F data.
+   * @throws InternalServerErrorException when required event payload fields
+   * are missing for a First2Finish challenge.
+   */
+  private async publishFirst2FinishSubmissionEventIfEligible(
+    submission: RapidSubmissionRecord,
+  ): Promise<void> {
+    if (!submission.challengeId) {
+      this.logger.log(
+        `Submission ${submission.id} missing challengeId. Skipping First2Finish event publish.`,
+      );
+      return;
+    }
+
+    const challenge = await this.challengeApiService.getChallengeDetail(
+      submission.challengeId,
+    );
+
+    if (!this.isFirst2FinishTypeName(challenge?.type)) {
+      this.logger.log(
+        `Challenge ${submission.challengeId} is not First2Finish. Skipping immediate First2Finish event for submission ${submission.id}.`,
+      );
+      return;
+    }
+
+    if (!submission.url) {
+      throw new InternalServerErrorException({
+        message:
+          'Updated submission does not contain a URL required for First2Finish event payload.',
+        code: 'FIRST2FINISH_SUBMISSION_URL_MISSING',
+        details: { submissionId: submission.id },
+      });
+    }
+
+    if (!submission.memberId) {
+      throw new InternalServerErrorException({
+        message:
+          'Submission is missing memberId. Cannot publish First2Finish event.',
+        code: 'FIRST2FINISH_SUBMISSION_MEMBER_MISSING',
+        details: { submissionId: submission.id },
+      });
+    }
+
+    const memberHandle = await this.lookupMemberHandle(
+      submission.challengeId,
+      submission.memberId,
+    );
+
+    if (!memberHandle) {
+      throw new InternalServerErrorException({
+        message:
+          'Unable to locate member handle for First2Finish event payload.',
+        code: 'FIRST2FINISH_MEMBER_HANDLE_MISSING',
+        details: {
+          submissionId: submission.id,
+          challengeId: submission.challengeId,
+          memberId: submission.memberId,
+        },
+      });
+    }
+
+    const payload: RapidSubmissionEventPayload = {
+      submissionId: submission.id,
+      challengeId: submission.challengeId,
+      submissionUrl: submission.url,
+      memberHandle,
+      memberId: submission.memberId,
+      submittedDate: submission.createdAt.toISOString(),
+    };
+
+    await this.eventBusService.publish(
+      'first2finish.submission.received',
+      payload,
+    );
+    this.logger.log(
+      `Published first2finish.submission.received event for submission ${submission.id} immediately after creation.`,
+    );
+  }
+
   private async publishTopgearSubmissionEventIfEligible(
-    submission: TopgearSubmissionRecord,
+    submission: RapidSubmissionRecord,
   ): Promise<void> {
     if (!submission.challengeId) {
       this.logger.log(
@@ -2765,7 +2852,7 @@ export class SubmissionService {
       });
     }
 
-    const payload: TopgearSubmissionEventPayload = {
+    const payload: RapidSubmissionEventPayload = {
       submissionId: submission.id,
       challengeId: submission.challengeId,
       submissionUrl: submission.url,
@@ -2782,6 +2869,17 @@ export class SubmissionService {
 
   private isTopgearTaskChallenge(typeName?: string): boolean {
     return (typeName ?? '').trim().toLowerCase() === 'topgear task';
+  }
+
+  /**
+   * Checks whether a challenge type name is the First2Finish type used by
+   * rapid-submission event routing.
+   *
+   * @param typeName - Challenge type name returned by challenge-api.
+   * @returns True when the type name matches First2Finish.
+   */
+  private isFirst2FinishTypeName(typeName?: string): boolean {
+    return (typeName ?? '').toString().trim().toLowerCase() === 'first2finish';
   }
 
   private async lookupMemberHandle(
@@ -3113,6 +3211,15 @@ export class SubmissionService {
         this.logger.log(
           `Skipping AV scan event for submission ${data.id} because it is not a file-based submission.`,
         );
+        if (data.type === SubmissionType.CONTEST_SUBMISSION) {
+          await this.publishFirst2FinishSubmissionEventIfEligible({
+            id: data.id,
+            challengeId: data.challengeId,
+            memberId: data.memberId,
+            url: data.url,
+            createdAt: data.createdAt,
+          });
+        }
         await this.publishTopgearSubmissionEventIfEligible({
           id: data.id,
           challengeId: data.challengeId,


### PR DESCRIPTION
What was broken
URL-based First2Finish contest submissions skip AV scanning, but only the scan-complete path published first2finish.submission.received. Autopilot did not receive a rapid-submission event for URL submissions, so the seeded Iterative Review phase could remain pending after submission.

Root cause
The non-file submission creation path had an immediate Topgear event publisher but no equivalent First2Finish event publisher.

What was changed
Added an immediate first2finish.submission.received publish path for non-file contest submissions when the challenge type is First2Finish. The payload matches the scan-complete F2F event fields used by autopilot, while file-backed submissions continue to use the AV scan completion path.

Any added/updated tests
Added a createSubmission regression test that verifies a URL-based First2Finish contest submission publishes first2finish.submission.received and does not request AV scanning.

Validation run:
- pnpm test -- submission.service.spec.ts --runInBand -t "publishes first2finish.submission.received immediately for URL submissions" passed.
- pnpm lint passed.
- pnpm build passed.
- pnpm test -- --runInBand --silent currently fails in unrelated existing specs: five listSubmission expectations in submission.service.spec.ts and two appeal response mock expectations in appeal.service.spec.ts.
