### PR TITLE
PM-5663: Restore marathon test progress metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,5 @@ $ pnpm run test:cov
 ## Review summation metadata
 
 `GET /v6/reviewSummations?metadata=true` returns full metadata for admins, copilots, and machine clients. Member/submitter requests are limited to their own Marathon Match submissions and receive only progress metadata: `testProcess`, `testProgress`, `testStatus`, and safe count/timestamp fields in `testProgressDetails`. Per-seed scores and runner messages are not returned to competitors.
+
+Submission responses include that same safe progress subset in nested review summations. The allowlisted process values are `example`, `provisional`, and `system`; raw test scores, seeds, and runner messages remain excluded.

--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -2417,7 +2417,7 @@ describe('SubmissionService', () => {
       expect(submissionResult.url).toBeNull();
     });
 
-    it('omits review summation metadata for submitter-owned submissions', async () => {
+    it('returns safe review summation progress metadata for submissions', async () => {
       const now = new Date('2026-05-01T12:00:00Z');
       const submissions = [
         {
@@ -2434,7 +2434,7 @@ describe('SubmissionService', () => {
             {
               id: 'summation-own',
               metadata: {
-                testProcess: 'system',
+                testType: 'example',
                 testProgress: 0.75,
                 testStatus: 'IN PROGRESS',
                 testScores: [
@@ -2479,15 +2479,21 @@ describe('SubmissionService', () => {
       );
 
       const findManyArg = prismaMock.submission.findMany.mock.calls[0][0];
-      expect(findManyArg.include.reviewSummation.select).not.toHaveProperty(
-        'metadata',
-      );
-      expect(result.data[0].reviewSummation?.[0]).not.toHaveProperty(
-        'metadata',
-      );
-      expect(JSON.stringify(result.data[0].reviewSummation)).not.toContain(
-        '987654321',
-      );
+      expect(findManyArg.include.reviewSummation.select.metadata).toBe(true);
+
+      const metadata = result.data[0].reviewSummation?.[0].metadata;
+      expect(metadata).toEqual({
+        testProgress: 0.75,
+        testStatus: 'IN PROGRESS',
+        testType: 'example',
+        testProgressDetails: {
+          completedTests: 15,
+          progress: 0.75,
+          status: 'IN PROGRESS',
+          totalTests: 20,
+        },
+      });
+      expect(JSON.stringify(metadata)).not.toContain('987654321');
     });
   });
 

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -35,6 +35,7 @@ import {
   ChallengeApiService,
   ChallengeData,
 } from 'src/shared/modules/global/challenge.service';
+import { buildSafeReviewSummationMetadata } from 'src/shared/utils/review-summation-metadata.util';
 import { ChallengeCatalogService } from 'src/shared/modules/global/challenge-catalog.service';
 import { ResourceApiService } from 'src/shared/modules/global/resource.service';
 import { ResourcePrismaService } from 'src/shared/modules/global/resource-prisma.service';
@@ -230,6 +231,7 @@ const REVIEW_SUMMATION_RESPONSE_SELECT = {
   createdBy: true,
   updatedAt: true,
   updatedBy: true,
+  metadata: true,
 } satisfies Prisma.reviewSummationSelect;
 
 type CreateSubmissionOptions = {
@@ -6067,13 +6069,13 @@ export class SubmissionService {
   }
 
   /**
-   * Removes individual review summation metadata from nested submission responses.
+   * Replaces nested review summation metadata with member-safe test progress fields.
    * @param reviewSummation Raw nested review summation rows from Prisma.
-   * @returns Review summation rows without metadata fields, or undefined when absent.
+   * @returns Review summation rows with sanitized metadata, or undefined when absent.
    * @throws This method does not throw.
-   * Used by `buildResponse` as a response-boundary guard against leaking per-seed data.
+   * Used by `buildResponse` to expose Marathon Match progress without leaking per-seed data.
    */
-  private stripReviewSummationMetadata(
+  private sanitizeReviewSummationMetadata(
     reviewSummation: unknown,
   ): unknown[] | undefined {
     if (!Array.isArray(reviewSummation)) {
@@ -6086,9 +6088,11 @@ export class SubmissionService {
         return summation;
       }
 
-      const safeSummation = { ...(summation as Record<string, unknown>) };
-      delete safeSummation.metadata;
-      return safeSummation;
+      const typedSummation = summation as Record<string, unknown>;
+      return {
+        ...typedSummation,
+        metadata: buildSafeReviewSummationMetadata(typedSummation.metadata),
+      };
     });
   }
 
@@ -6102,7 +6106,7 @@ export class SubmissionService {
       dto.review = data.review as ReviewResponseDto[];
     }
     if (data.reviewSummation) {
-      dto.reviewSummation = this.stripReviewSummationMetadata(
+      dto.reviewSummation = this.sanitizeReviewSummationMetadata(
         data.reviewSummation,
       ) as any[];
     }

--- a/src/shared/utils/review-summation-metadata.util.ts
+++ b/src/shared/utils/review-summation-metadata.util.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 
 type MetadataRecord = Record<string, unknown>;
-type SafeTestProcess = 'provisional' | 'system';
+type SafeTestProcess = 'example' | 'provisional' | 'system';
 type SafeTestStatus = 'FAILED' | 'IN PROGRESS' | 'SUCCESS';
 const ISO_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
@@ -19,7 +19,7 @@ function isMetadataRecord(value: unknown): value is MetadataRecord {
 /**
  * Normalizes test process metadata to the member-visible process values.
  * @param value Raw metadata value.
- * @returns Safe process value, or `undefined` when the value is unsupported.
+ * @returns Safe example, provisional, or system process value, or `undefined` when unsupported.
  * Used by `buildSafeReviewSummationMetadata` to avoid leaking free-form text.
  */
 function normalizeTestProcess(value: unknown): SafeTestProcess | undefined {
@@ -27,7 +27,9 @@ function normalizeTestProcess(value: unknown): SafeTestProcess | undefined {
     return undefined;
   }
   const normalized = value.trim().toLowerCase();
-  return normalized === 'provisional' || normalized === 'system'
+  return normalized === 'example' ||
+    normalized === 'provisional' ||
+    normalized === 'system'
     ? normalized
     : undefined;
 }


### PR DESCRIPTION
## What was broken

Work Manager Marathon Match submission rows showed blank Current tests process, Test status, and Test progress columns even though scoring had completed or was in progress.

## Root cause

The submissions endpoint stopped selecting nested review summation metadata and removed it at the response boundary. Marathon Match scoring still persisted the values, and the Work UI still rendered them, but the required data no longer reached the UI.

## What was changed

- Select nested review summation metadata for submission responses.
- Reduce it at the response boundary to the existing safe progress allowlist.
- Support Example, Provisional, and System process values.
- Continue excluding raw test scores, seeds, runner messages, and arbitrary metadata.
- Document the safe nested metadata contract.

## Any added/updated tests

- Updated the submission service regression test to verify Example process, status, and progress metadata are returned while seed-bearing scorer details remain excluded.
- Ticket-specific API regression test passes.
- Existing Work UI progress extraction/rendering suites pass: 25 tests.
- Lint passes.
- Build passes.
- Full API suite result: 202 passed and 7 failed. All 7 failures reproduce unchanged on `origin/develop` (5 existing submission visibility/latest assertions and 2 existing appeal-response mock failures).
