### PR TITLE
PM-5665 instant review

### DIFF
--- a/prisma/migrations/20260608120000_add_instant_review_flag/migration.sql
+++ b/prisma/migrations/20260608120000_add_instant_review_flag/migration.sql
@@ -1,0 +1,3 @@
+-- Add instantReview flag on aiReviewConfig.
+ALTER TABLE "aiReviewConfig"
+ADD COLUMN "instantReview" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -790,6 +790,7 @@ model aiReviewConfig {
   version             Int          @default(1)
   minPassingThreshold  Decimal      @db.Decimal(5, 2)
   autoFinalize         Boolean      @default(false)
+  instantReview        Boolean      @default(false)
   mode                 AiReviewMode @default(AI_GATING)
   formula             Json?
 

--- a/src/api/ai-review-config/ai-review-config.service.ts
+++ b/src/api/ai-review-config/ai-review-config.service.ts
@@ -84,6 +84,7 @@ type AiReviewConfigRecord = {
   minPassingThreshold: Prisma.Decimal | number | string | null;
   mode: PrismaAiReviewMode;
   autoFinalize: boolean;
+  instantReview: boolean;
   formula: Prisma.JsonValue | null;
   templateId: string | null;
   createdAt: Date;
@@ -137,6 +138,7 @@ export class AiReviewConfigService {
           : 0,
       mode: this.mapModeToResponse(config.mode),
       autoFinalize: config.autoFinalize,
+      instantReview: config.instantReview,
       formula,
       templateId: config.templateId,
       createdAt: config.createdAt,
@@ -393,6 +395,7 @@ export class AiReviewConfigService {
       minPassingThreshold: number;
       mode: PrismaAiReviewMode;
       autoFinalize: boolean;
+      instantReview: boolean;
       formula?: Prisma.InputJsonValue;
       templateId?: string;
       workflows: CreateAiReviewConfigDto['workflows'];
@@ -401,6 +404,7 @@ export class AiReviewConfigService {
       minPassingThreshold: dto.minPassingThreshold,
       mode: dto.mode as PrismaAiReviewMode,
       autoFinalize: dto.autoFinalize,
+      instantReview: dto.instantReview ?? false,
       formula:
         dto.formula != null
           ? (dto.formula as Prisma.InputJsonValue)
@@ -439,6 +443,7 @@ export class AiReviewConfigService {
             ? (dto.formula as Prisma.InputJsonValue)
             : (template.formula as Prisma.InputJsonValue | undefined),
         templateId: template.id,
+        instantReview: dto.instantReview ?? false,
         workflows: dto.workflows.length
           ? dto.workflows
           : template.workflows.map((w) => ({
@@ -467,6 +472,7 @@ export class AiReviewConfigService {
           minPassingThreshold: configData.minPassingThreshold,
           mode: configData.mode,
           autoFinalize: configData.autoFinalize,
+          instantReview: configData.instantReview,
           formula: configData.formula,
           templateId: configData.templateId,
         },
@@ -553,6 +559,8 @@ export class AiReviewConfigService {
       configData.mode = rest.mode as PrismaAiReviewMode;
     if (rest.autoFinalize !== undefined)
       configData.autoFinalize = rest.autoFinalize;
+    if (rest.instantReview !== undefined)
+      configData.instantReview = rest.instantReview;
     if (rest.formula !== undefined)
       configData.formula = rest.formula as Prisma.InputJsonValue;
 

--- a/src/dto/aiReviewConfig.dto.ts
+++ b/src/dto/aiReviewConfig.dto.ts
@@ -85,9 +85,12 @@ export class CreateAiReviewConfigDto {
   @ApiProperty({
     description: 'Whether AI review should be dispatched immediately after scan completion',
     example: false,
+    required: false,
+    default: false,
   })
+  @IsOptional()
   @IsBoolean()
-  instantReview: boolean;
+  instantReview?: boolean;
 
   @ApiProperty({
     description: 'Optional formula configuration (JSON object)',

--- a/src/dto/aiReviewConfig.dto.ts
+++ b/src/dto/aiReviewConfig.dto.ts
@@ -83,6 +83,13 @@ export class CreateAiReviewConfigDto {
   autoFinalize: boolean;
 
   @ApiProperty({
+    description: 'Whether AI review should be dispatched immediately after scan completion',
+    example: false,
+  })
+  @IsBoolean()
+  instantReview: boolean;
+
+  @ApiProperty({
     description: 'Optional formula configuration (JSON object)',
     required: false,
   })
@@ -170,6 +177,9 @@ export class AiReviewConfigResponseDto {
 
   @ApiProperty({ description: 'Auto-finalize enabled' })
   autoFinalize: boolean;
+
+  @ApiProperty({ description: 'Instant Review enabled' })
+  instantReview: boolean;
 
   @ApiProperty({ description: 'Formula configuration', required: false })
   formula?: Record<string, unknown>;

--- a/src/shared/modules/global/ai-phase-opened.orchestrator.spec.ts
+++ b/src/shared/modules/global/ai-phase-opened.orchestrator.spec.ts
@@ -1,0 +1,61 @@
+jest.mock('./prisma.service', () => ({
+  PrismaService: class PrismaService {},
+}));
+
+jest.mock('./ai-workflow-queue.service', () => ({
+  AiWorkflowQueueService: class AiWorkflowQueueService {},
+}));
+
+import { AiPhaseOpenedOrchestrator } from './ai-phase-opened.orchestrator';
+
+describe('AiPhaseOpenedOrchestrator', () => {
+  const prismaMock = {
+    $queryRaw: jest.fn(),
+  };
+  const aiWorkflowQueueServiceMock = {
+    queueWorkflowsForSubmission: jest.fn(),
+  };
+  let orchestrator: AiPhaseOpenedOrchestrator;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    orchestrator = new AiPhaseOpenedOrchestrator(
+      prismaMock as any,
+      aiWorkflowQueueServiceMock as any,
+    );
+  });
+
+  it('queues workflows for each latest contest submission on challenge AI phase opened', async () => {
+    prismaMock.$queryRaw.mockResolvedValueOnce([
+      { id: 'submission-1' },
+      { id: 'submission-2' },
+    ]);
+
+    await orchestrator.orchestrateChallengePhaseOpened('challenge-1');
+
+    expect(prismaMock.$queryRaw).toHaveBeenCalled();
+    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).toHaveBeenCalledTimes(2);
+    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).toHaveBeenCalledWith(
+      'submission-1',
+    );
+    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).toHaveBeenCalledWith(
+      'submission-2',
+    );
+  });
+
+  it('skips orchestration when challengeId is missing', async () => {
+    await orchestrator.orchestrateChallengePhaseOpened('');
+
+    expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
+    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).not.toHaveBeenCalled();
+  });
+
+  it('skips when there are no latest submissions', async () => {
+    prismaMock.$queryRaw.mockResolvedValueOnce([]);
+
+    await orchestrator.orchestrateChallengePhaseOpened('challenge-1');
+
+    expect(prismaMock.$queryRaw).toHaveBeenCalled();
+    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/modules/global/ai-phase-opened.orchestrator.spec.ts
+++ b/src/shared/modules/global/ai-phase-opened.orchestrator.spec.ts
@@ -34,20 +34,24 @@ describe('AiPhaseOpenedOrchestrator', () => {
     await orchestrator.orchestrateChallengePhaseOpened('challenge-1');
 
     expect(prismaMock.$queryRaw).toHaveBeenCalled();
-    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).toHaveBeenCalledTimes(2);
-    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).toHaveBeenCalledWith(
-      'submission-1',
-    );
-    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).toHaveBeenCalledWith(
-      'submission-2',
-    );
+    expect(
+      aiWorkflowQueueServiceMock.queueWorkflowsForSubmission,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      aiWorkflowQueueServiceMock.queueWorkflowsForSubmission,
+    ).toHaveBeenCalledWith('submission-1', { aiPhaseOpened: true });
+    expect(
+      aiWorkflowQueueServiceMock.queueWorkflowsForSubmission,
+    ).toHaveBeenCalledWith('submission-2', { aiPhaseOpened: true });
   });
 
   it('skips orchestration when challengeId is missing', async () => {
     await orchestrator.orchestrateChallengePhaseOpened('');
 
     expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
-    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).not.toHaveBeenCalled();
+    expect(
+      aiWorkflowQueueServiceMock.queueWorkflowsForSubmission,
+    ).not.toHaveBeenCalled();
   });
 
   it('skips when there are no latest submissions', async () => {
@@ -56,6 +60,8 @@ describe('AiPhaseOpenedOrchestrator', () => {
     await orchestrator.orchestrateChallengePhaseOpened('challenge-1');
 
     expect(prismaMock.$queryRaw).toHaveBeenCalled();
-    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).not.toHaveBeenCalled();
+    expect(
+      aiWorkflowQueueServiceMock.queueWorkflowsForSubmission,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/modules/global/ai-phase-opened.orchestrator.ts
+++ b/src/shared/modules/global/ai-phase-opened.orchestrator.ts
@@ -35,6 +35,7 @@ export class AiPhaseOpenedOrchestrator {
         try {
           await this.aiWorkflowQueueService.queueWorkflowsForSubmission(
             submissionId,
+            { aiPhaseOpened: true },
           );
         } catch (error) {
           const err = error as Error;

--- a/src/shared/modules/global/ai-phase-opened.orchestrator.ts
+++ b/src/shared/modules/global/ai-phase-opened.orchestrator.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from './prisma.service';
+import { AiWorkflowQueueService } from './ai-workflow-queue.service';
+
+@Injectable()
+export class AiPhaseOpenedOrchestrator {
+  private readonly logger = new Logger(AiPhaseOpenedOrchestrator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly aiWorkflowQueueService: AiWorkflowQueueService,
+  ) {}
+
+  async orchestrateChallengePhaseOpened(challengeId: string): Promise<void> {
+    if (!challengeId) {
+      this.logger.warn('Skipping AI phase opened orchestration because challengeId is missing.');
+      return;
+    }
+
+    try {
+      const submissionIds = await this.getLatestContestSubmissionIds(challengeId);
+      if (!submissionIds.length) {
+        this.logger.log(
+          `No latest contest submissions found for challenge ${challengeId}; skipping AI workflow queueing.`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Dispatching AI workflow queueing for ${submissionIds.length} latest submission(s) on challenge ${challengeId}.`,
+      );
+
+      for (const submissionId of submissionIds) {
+        try {
+          await this.aiWorkflowQueueService.queueWorkflowsForSubmission(
+            submissionId,
+          );
+        } catch (error) {
+          const err = error as Error;
+          this.logger.error(
+            `Failed to queue AI workflows for submission ${submissionId} on challenge ${challengeId}: ${err.message}`,
+            err.stack,
+          );
+        }
+      }
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `Failed to determine latest submissions for challenge ${challengeId}: ${err.message}`,
+        err.stack,
+      );
+      throw err;
+    }
+  }
+
+  private async getLatestContestSubmissionIds(
+    challengeId: string,
+  ): Promise<string[]> {
+    const query = Prisma.sql`
+      WITH latest_submissions AS (
+        SELECT
+          s."id",
+          ROW_NUMBER() OVER (
+            PARTITION BY COALESCE(s."memberId", s."id")
+            ORDER BY
+              s."submittedDate" DESC NULLS LAST,
+              s."createdAt" DESC NULLS LAST,
+              s."updatedAt" DESC NULLS LAST,
+              s."id" DESC
+          ) AS row_num
+        FROM ${Prisma.sql`"submission"`} s
+        WHERE s."challengeId" = ${challengeId}
+          AND (s."status" = 'ACTIVE' OR s."status" IS NULL)
+          AND (
+            s."type" IS NULL
+            OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
+          )
+      )
+      SELECT "id"
+      FROM latest_submissions
+      WHERE row_num = 1
+    `;
+
+    const rows = await this.prisma.$queryRaw<Array<{ id: string }>>(query);
+    return rows.map((row) => row.id).filter(Boolean);
+  }
+}

--- a/src/shared/modules/global/ai-workflow-queue.service.spec.ts
+++ b/src/shared/modules/global/ai-workflow-queue.service.spec.ts
@@ -51,6 +51,7 @@ describe('AiWorkflowQueueService', () => {
     });
     prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
       instantReview: true,
+      template: { disabled: false },
       workflows: [
         { workflowId: 'workflow-a' },
         { workflowId: 'workflow-a' },
@@ -65,6 +66,30 @@ describe('AiWorkflowQueueService', () => {
       [{ id: 'workflow-a' }, { id: 'workflow-b' }],
       'challenge-1',
       'submission-1',
+    );
+  });
+
+  it('queues workflows during AI phase opened event even when instantReview is disabled', async () => {
+    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
+      id: 'submission-5',
+      challengeId: 'challenge-5',
+    });
+    prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
+      instantReview: false,
+      template: { disabled: false },
+      workflows: [
+        { workflowId: 'workflow-c' },
+      ],
+    });
+
+    await service.queueWorkflowsForSubmission('submission-5', {
+      aiPhaseOpened: true,
+    });
+
+    expect(workflowQueueHandlerMock.queueWorkflowRuns).toHaveBeenCalledWith(
+      [{ id: 'workflow-c' }],
+      'challenge-5',
+      'submission-5',
     );
   });
 

--- a/src/shared/modules/global/ai-workflow-queue.service.spec.ts
+++ b/src/shared/modules/global/ai-workflow-queue.service.spec.ts
@@ -1,0 +1,120 @@
+jest.mock('./submission-base.service', () => ({
+  SubmissionBaseService: class SubmissionBaseService {},
+}));
+
+jest.mock('./challenge.service', () => ({
+  ChallengeApiService: class ChallengeApiService {},
+}));
+
+jest.mock('./workflow-queue.handler', () => ({
+  WorkflowQueueHandler: class WorkflowQueueHandler {},
+}));
+
+jest.mock('./prisma.service', () => ({
+  PrismaService: class PrismaService {},
+}));
+
+import { AiWorkflowQueueService } from './ai-workflow-queue.service';
+
+describe('AiWorkflowQueueService', () => {
+  const submissionBaseServiceMock = {
+    getSubmissionById: jest.fn(),
+  };
+  const challengeApiServiceMock = {
+    getChallengeDetail: jest.fn(),
+  };
+  const workflowQueueHandlerMock = {
+    queueWorkflowRuns: jest.fn(),
+  };
+  const prismaMock = {
+    aiReviewConfig: {
+      findFirst: jest.fn(),
+    },
+  };
+
+  let service: AiWorkflowQueueService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AiWorkflowQueueService(
+      submissionBaseServiceMock as any,
+      challengeApiServiceMock as any,
+      workflowQueueHandlerMock as any,
+      prismaMock as any,
+    );
+  });
+
+  it('queues workflows from active AI review config when instantReview is enabled', async () => {
+    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
+      id: 'submission-1',
+      challengeId: 'challenge-1',
+    });
+    prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
+      instantReview: true,
+      workflows: [
+        { workflowId: 'workflow-a' },
+        { workflowId: 'workflow-a' },
+        { workflowId: 'workflow-b' },
+      ],
+    });
+
+    await service.queueWorkflowsForSubmission('submission-1');
+
+    expect(challengeApiServiceMock.getChallengeDetail).not.toHaveBeenCalled();
+    expect(workflowQueueHandlerMock.queueWorkflowRuns).toHaveBeenCalledWith(
+      [{ id: 'workflow-a' }, { id: 'workflow-b' }],
+      'challenge-1',
+      'submission-1',
+    );
+  });
+
+  it('does not queue workflows when instantReview is disabled on active AI review config', async () => {
+    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
+      id: 'submission-2',
+      challengeId: 'challenge-2',
+    });
+    prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
+      instantReview: false,
+      workflows: [{ workflowId: 'workflow-a' }],
+    });
+
+    await service.queueWorkflowsForSubmission('submission-2');
+
+    expect(challengeApiServiceMock.getChallengeDetail).not.toHaveBeenCalled();
+    expect(workflowQueueHandlerMock.queueWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  it('falls back to challenge-linked workflows when no AI review config exists', async () => {
+    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
+      id: 'submission-3',
+      challengeId: 'challenge-3',
+    });
+    prismaMock.aiReviewConfig.findFirst.mockResolvedValue(null);
+    challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+      id: 'challenge-3',
+      workflows: [{ id: 'legacy-workflow-1' }, { id: 'legacy-workflow-2' }],
+    });
+
+    await service.queueWorkflowsForSubmission('submission-3');
+
+    expect(challengeApiServiceMock.getChallengeDetail).toHaveBeenCalledWith(
+      'challenge-3',
+    );
+    expect(workflowQueueHandlerMock.queueWorkflowRuns).toHaveBeenCalledWith(
+      [{ id: 'legacy-workflow-1' }, { id: 'legacy-workflow-2' }],
+      'challenge-3',
+      'submission-3',
+    );
+  });
+
+  it('skips queueing when submission challengeId is missing', async () => {
+    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
+      id: 'submission-4',
+      challengeId: null,
+    });
+
+    await service.queueWorkflowsForSubmission('submission-4');
+
+    expect(workflowQueueHandlerMock.queueWorkflowRuns).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/modules/global/ai-workflow-queue.service.spec.ts
+++ b/src/shared/modules/global/ai-workflow-queue.service.spec.ts
@@ -131,7 +131,20 @@ describe('AiWorkflowQueueService', () => {
       'submission-3',
     );
   });
-
+  it('skips queueing when active AI review config template is disabled', async () => {
+    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
+      id: 'submission-6',
+      challengeId: 'challenge-6',
+    });
+    prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
+      instantReview: true,
+      template: { disabled: true },
+      workflows: [{ workflowId: 'workflow-a' }],
+    });
+    await service.queueWorkflowsForSubmission('submission-6');
+    expect(challengeApiServiceMock.getChallengeDetail).not.toHaveBeenCalled();
+    expect(workflowQueueHandlerMock.queueWorkflowRuns).not.toHaveBeenCalled();
+  });
   it('skips queueing when submission challengeId is missing', async () => {
     submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
       id: 'submission-4',

--- a/src/shared/modules/global/ai-workflow-queue.service.ts
+++ b/src/shared/modules/global/ai-workflow-queue.service.ts
@@ -15,7 +15,10 @@ export class AiWorkflowQueueService {
     private readonly prisma: PrismaService,
   ) {}
 
-  async queueWorkflowsForSubmission(submissionId: string): Promise<void> {
+  async queueWorkflowsForSubmission(
+    submissionId: string,
+    options?: { aiPhaseOpened?: boolean },
+  ): Promise<void> {
     this.logger.log(`Queueing AI workflows for submission ${submissionId}`);
 
     const submission = await this.submissionBaseService.getSubmissionById(
@@ -29,7 +32,10 @@ export class AiWorkflowQueueService {
       return;
     }
 
-    const workflowIds = await this.resolveWorkflowIdsForChallenge(challengeId);
+    const workflowIds = await this.resolveWorkflowIdsForChallenge(
+      challengeId,
+      options,
+    );
     if (!workflowIds.length) {
       this.logger.log(
         `No AI workflows configured for challenge ${challengeId}; skipping queueing for submission ${submissionId}.`,
@@ -46,13 +52,18 @@ export class AiWorkflowQueueService {
 
   private async resolveWorkflowIdsForChallenge(
     challengeId: string,
+    options?: { aiPhaseOpened?: boolean },
   ): Promise<string[]> {
     const configured = await this.getConfiguredAiWorkflowIds(challengeId);
-    if (configured?.mode === 'queue') {
-      return configured.workflowIds;
-    }
+    if (configured) {
+      if (configured.templateDisabled) {
+        return [];
+      }
 
-    if (configured?.mode === 'skip') {
+      if (configured.instantReviewEnabled || options?.aiPhaseOpened) {
+        return configured.workflowIds;
+      }
+
       return [];
     }
 
@@ -72,12 +83,15 @@ export class AiWorkflowQueueService {
   private async getConfiguredAiWorkflowIds(
     challengeId: string,
   ): Promise<
-    | { mode: 'queue'; workflowIds: string[] }
-    | { mode: 'skip' }
-    | { mode: 'fallback' }
+    | {
+        instantReviewEnabled: boolean;
+        templateDisabled: boolean;
+        workflowIds: string[];
+      }
+    | null
   > {
     if (!challengeId) {
-      return { mode: 'fallback' };
+      return null;
     }
 
     const config = await this.prisma.aiReviewConfig.findFirst({
@@ -102,36 +116,25 @@ export class AiWorkflowQueueService {
     });
 
     if (!config) {
-      return { mode: 'fallback' };
+      return null;
     }
 
-    if (config.template?.disabled) {
-      this.logger.warn(
-        `Skipping AI workflow queueing for challenge ${challengeId} because linked template is disabled.`,
-      );
-      return { mode: 'skip' };
-    }
-
-    if (config.instantReview !== true) {
-      this.logger.log(
-        `Skipping AI workflow queueing for challenge ${challengeId} because instantReview is disabled.`,
-      );
-      return { mode: 'skip' };
-    }
+    const workflowIds = Array.from(
+      new Set(
+        (config.workflows ?? [])
+          .map((workflow: { workflowId?: unknown }) =>
+            typeof workflow.workflowId === 'string'
+              ? workflow.workflowId
+              : undefined,
+          )
+          .filter((workflowId): workflowId is string => Boolean(workflowId)),
+      ),
+    );
 
     return {
-      mode: 'queue',
-      workflowIds: Array.from(
-        new Set(
-          (config.workflows ?? [])
-            .map((workflow: { workflowId?: unknown }) =>
-              typeof workflow.workflowId === 'string'
-                ? workflow.workflowId
-                : undefined,
-            )
-            .filter((workflowId): workflowId is string => Boolean(workflowId)),
-        ),
-      ),
+      instantReviewEnabled: config.instantReview === true,
+      templateDisabled: !!config.template?.disabled,
+      workflowIds,
     };
   }
 }

--- a/src/shared/modules/global/ai-workflow-queue.service.ts
+++ b/src/shared/modules/global/ai-workflow-queue.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SubmissionBaseService } from './submission-base.service';
+import { ChallengeApiService } from './challenge.service';
+import { WorkflowQueueHandler } from './workflow-queue.handler';
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class AiWorkflowQueueService {
+  private readonly logger = new Logger(AiWorkflowQueueService.name);
+
+  constructor(
+    private readonly submissionBaseService: SubmissionBaseService,
+    private readonly challengeApiService: ChallengeApiService,
+    private readonly workflowQueueHandler: WorkflowQueueHandler,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async queueWorkflowsForSubmission(submissionId: string): Promise<void> {
+    this.logger.log(`Queueing AI workflows for submission ${submissionId}`);
+
+    const submission = await this.submissionBaseService.getSubmissionById(
+      submissionId,
+    );
+    const challengeId = String(submission.challengeId ?? '').trim();
+    if (!challengeId) {
+      this.logger.warn(
+        `Skipping AI workflow queueing because submission ${submissionId} is missing challengeId.`,
+      );
+      return;
+    }
+
+    const workflowIds = await this.resolveWorkflowIdsForChallenge(challengeId);
+    if (!workflowIds.length) {
+      this.logger.log(
+        `No AI workflows configured for challenge ${challengeId}; skipping queueing for submission ${submissionId}.`,
+      );
+      return;
+    }
+
+    await this.workflowQueueHandler.queueWorkflowRuns(
+      workflowIds.map((id) => ({ id })),
+      challengeId,
+      submissionId,
+    );
+  }
+
+  private async resolveWorkflowIdsForChallenge(
+    challengeId: string,
+  ): Promise<string[]> {
+    const configured = await this.getConfiguredAiWorkflowIds(challengeId);
+    if (configured?.mode === 'queue') {
+      return configured.workflowIds;
+    }
+
+    if (configured?.mode === 'skip') {
+      return [];
+    }
+
+    const challenge = await this.challengeApiService.getChallengeDetail(
+      challengeId,
+    );
+
+    return Array.from(
+      new Set(
+        (challenge.workflows ?? [])
+          .map((workflow) => workflow?.id)
+          .filter((workflowId): workflowId is string => Boolean(workflowId)),
+      ),
+    );
+  }
+
+  private async getConfiguredAiWorkflowIds(
+    challengeId: string,
+  ): Promise<
+    | { mode: 'queue'; workflowIds: string[] }
+    | { mode: 'skip' }
+    | { mode: 'fallback' }
+  > {
+    if (!challengeId) {
+      return { mode: 'fallback' };
+    }
+
+    const config = await this.prisma.aiReviewConfig.findFirst({
+      where: { challengeId },
+      orderBy: { version: 'desc' },
+      select: {
+        template: {
+          select: {
+            disabled: true,
+          },
+        },
+        instantReview: true,
+        workflows: {
+          where: {
+            workflow: {
+              disabled: false,
+            },
+          },
+          select: { workflowId: true },
+        },
+      },
+    });
+
+    if (!config) {
+      return { mode: 'fallback' };
+    }
+
+    if (config.template?.disabled) {
+      this.logger.warn(
+        `Skipping AI workflow queueing for challenge ${challengeId} because linked template is disabled.`,
+      );
+      return { mode: 'skip' };
+    }
+
+    if (config.instantReview !== true) {
+      this.logger.log(
+        `Skipping AI workflow queueing for challenge ${challengeId} because instantReview is disabled.`,
+      );
+      return { mode: 'skip' };
+    }
+
+    return {
+      mode: 'queue',
+      workflowIds: Array.from(
+        new Set(
+          (config.workflows ?? [])
+            .map((workflow: { workflowId?: unknown }) =>
+              typeof workflow.workflowId === 'string'
+                ? workflow.workflowId
+                : undefined,
+            )
+            .filter((workflowId): workflowId is string => Boolean(workflowId)),
+        ),
+      ),
+    };
+  }
+}

--- a/src/shared/modules/global/globalProviders.module.ts
+++ b/src/shared/modules/global/globalProviders.module.ts
@@ -16,6 +16,8 @@ import { KafkaModule } from '../kafka/kafka.module';
 import { SubmissionBaseService } from './submission-base.service';
 import { GiteaService } from './gitea.service';
 import { SubmissionScanCompleteOrchestrator } from './submission-scan-complete.orchestrator';
+import { AiPhaseOpenedOrchestrator } from './ai-phase-opened.orchestrator';
+import { AiWorkflowQueueService } from './ai-workflow-queue.service';
 import { ChallengeCatalogService } from './challenge-catalog.service';
 import { SubmissionService } from 'src/api/submission/submission.service';
 import { ChallengePrismaService } from './challenge-prisma.service';
@@ -23,6 +25,7 @@ import { MemberPrismaService } from './member-prisma.service';
 import { WorkflowQueueHandler } from './workflow-queue.handler';
 import { AiReviewerDecisionMakerService } from './ai-reviewer-decision-maker.service';
 import { SubmissionScanCompleteHandler } from '../kafka/handlers/submission-scan-complete.handler';
+import { AiPhaseOpenedHandler } from '../kafka/handlers/ai-phase-opened.handler';
 import { SubmissionVirusScanRetryService } from './submission-virus-scan-retry.service';
 
 // Global module for providing global providers
@@ -56,10 +59,13 @@ import { SubmissionVirusScanRetryService } from './submission-virus-scan-retry.s
     SubmissionBaseService,
     GiteaService,
     SubmissionScanCompleteOrchestrator,
+    AiPhaseOpenedOrchestrator,
+    AiWorkflowQueueService,
     SubmissionService,
     WorkflowQueueHandler,
     AiReviewerDecisionMakerService,
     SubmissionScanCompleteHandler,
+    AiPhaseOpenedHandler,
     SubmissionVirusScanRetryService,
   ],
   exports: [
@@ -80,9 +86,12 @@ import { SubmissionVirusScanRetryService } from './submission-virus-scan-retry.s
     SubmissionBaseService,
     GiteaService,
     SubmissionScanCompleteOrchestrator,
+    AiPhaseOpenedOrchestrator,
+    AiWorkflowQueueService,
     WorkflowQueueHandler,
     AiReviewerDecisionMakerService,
     SubmissionScanCompleteHandler,
+    AiPhaseOpenedHandler,
   ],
 })
 export class GlobalProvidersModule {}

--- a/src/shared/modules/global/submission-scan-complete.orchestrator.spec.ts
+++ b/src/shared/modules/global/submission-scan-complete.orchestrator.spec.ts
@@ -1,35 +1,12 @@
-jest.mock('./submission-base.service', () => ({
-  SubmissionBaseService: class SubmissionBaseService {},
-}));
-
-jest.mock('./challenge.service', () => ({
-  ChallengeApiService: class ChallengeApiService {},
-}));
-
-jest.mock('./workflow-queue.handler', () => ({
-  WorkflowQueueHandler: class WorkflowQueueHandler {},
-}));
-
-jest.mock('./prisma.service', () => ({
-  PrismaService: class PrismaService {},
+jest.mock('./ai-workflow-queue.service', () => ({
+  AiWorkflowQueueService: class AiWorkflowQueueService {},
 }));
 
 import { SubmissionScanCompleteOrchestrator } from './submission-scan-complete.orchestrator';
 
 describe('SubmissionScanCompleteOrchestrator', () => {
-  const submissionBaseServiceMock = {
-    getSubmissionById: jest.fn(),
-  };
-  const challengeApiServiceMock = {
-    getChallengeDetail: jest.fn(),
-  };
-  const workflowQueueHandlerMock = {
-    queueWorkflowRuns: jest.fn(),
-  };
-  const prismaMock = {
-    aiReviewConfig: {
-      findFirst: jest.fn(),
-    },
+  const aiWorkflowQueueServiceMock = {
+    queueWorkflowsForSubmission: jest.fn(),
   };
 
   let orchestrator: SubmissionScanCompleteOrchestrator;
@@ -37,73 +14,15 @@ describe('SubmissionScanCompleteOrchestrator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     orchestrator = new SubmissionScanCompleteOrchestrator(
-      submissionBaseServiceMock as any,
-      challengeApiServiceMock as any,
-      workflowQueueHandlerMock as any,
-      prismaMock as any,
+      aiWorkflowQueueServiceMock as any,
     );
   });
 
-  it('queues workflows from the active AI review config when scan completes', async () => {
-    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
-      id: 'submission-1',
-      challengeId: 'challenge-1',
-    });
-    prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
-      instantReview: true,
-      workflows: [
-        { workflowId: 'workflow-a' },
-        { workflowId: 'workflow-a' },
-        { workflowId: 'workflow-b' },
-      ],
-    });
-
+  it('delegates workflow queueing to the shared AI workflow queue service', async () => {
     await orchestrator.orchestrateScanComplete('submission-1');
 
-    expect(challengeApiServiceMock.getChallengeDetail).not.toHaveBeenCalled();
-    expect(workflowQueueHandlerMock.queueWorkflowRuns).toHaveBeenCalledWith(
-      [{ id: 'workflow-a' }, { id: 'workflow-b' }],
-      'challenge-1',
+    expect(aiWorkflowQueueServiceMock.queueWorkflowsForSubmission).toHaveBeenCalledWith(
       'submission-1',
-    );
-  });
-
-  it('does not queue workflows when instantReview is disabled on active AI review config', async () => {
-    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
-      id: 'submission-3',
-      challengeId: 'challenge-3',
-    });
-    prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
-      instantReview: false,
-      workflows: [{ workflowId: 'workflow-a' }],
-    });
-
-    await orchestrator.orchestrateScanComplete('submission-3');
-
-    expect(challengeApiServiceMock.getChallengeDetail).not.toHaveBeenCalled();
-    expect(workflowQueueHandlerMock.queueWorkflowRuns).not.toHaveBeenCalled();
-  });
-
-  it('falls back to challenge-linked workflows when no AI review config exists', async () => {
-    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
-      id: 'submission-2',
-      challengeId: 'challenge-2',
-    });
-    prismaMock.aiReviewConfig.findFirst.mockResolvedValue(null);
-    challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
-      id: 'challenge-2',
-      workflows: [{ id: 'legacy-workflow-1' }, { id: 'legacy-workflow-2' }],
-    });
-
-    await orchestrator.orchestrateScanComplete('submission-2');
-
-    expect(challengeApiServiceMock.getChallengeDetail).toHaveBeenCalledWith(
-      'challenge-2',
-    );
-    expect(workflowQueueHandlerMock.queueWorkflowRuns).toHaveBeenCalledWith(
-      [{ id: 'legacy-workflow-1' }, { id: 'legacy-workflow-2' }],
-      'challenge-2',
-      'submission-2',
     );
   });
 });

--- a/src/shared/modules/global/submission-scan-complete.orchestrator.spec.ts
+++ b/src/shared/modules/global/submission-scan-complete.orchestrator.spec.ts
@@ -50,6 +50,7 @@ describe('SubmissionScanCompleteOrchestrator', () => {
       challengeId: 'challenge-1',
     });
     prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
+      instantReview: true,
       workflows: [
         { workflowId: 'workflow-a' },
         { workflowId: 'workflow-a' },
@@ -65,6 +66,22 @@ describe('SubmissionScanCompleteOrchestrator', () => {
       'challenge-1',
       'submission-1',
     );
+  });
+
+  it('does not queue workflows when instantReview is disabled on active AI review config', async () => {
+    submissionBaseServiceMock.getSubmissionById.mockResolvedValue({
+      id: 'submission-3',
+      challengeId: 'challenge-3',
+    });
+    prismaMock.aiReviewConfig.findFirst.mockResolvedValue({
+      instantReview: false,
+      workflows: [{ workflowId: 'workflow-a' }],
+    });
+
+    await orchestrator.orchestrateScanComplete('submission-3');
+
+    expect(challengeApiServiceMock.getChallengeDetail).not.toHaveBeenCalled();
+    expect(workflowQueueHandlerMock.queueWorkflowRuns).not.toHaveBeenCalled();
   });
 
   it('falls back to challenge-linked workflows when no AI review config exists', async () => {

--- a/src/shared/modules/global/submission-scan-complete.orchestrator.ts
+++ b/src/shared/modules/global/submission-scan-complete.orchestrator.ts
@@ -1,9 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { SubmissionBaseService } from './submission-base.service';
-import { ChallengeApiService } from './challenge.service';
-import { SubmissionResponseDto } from 'src/dto/submission.dto';
-import { WorkflowQueueHandler } from './workflow-queue.handler';
-import { PrismaService } from './prisma.service';
+import { AiWorkflowQueueService } from './ai-workflow-queue.service';
 
 /**
  * Orchestrator for handling submission scan completion events.
@@ -16,61 +12,17 @@ export class SubmissionScanCompleteOrchestrator {
     SubmissionScanCompleteOrchestrator.name,
   );
 
-  /**
-   * Orchestrates the actions to be taken when a submission scan is complete.
-   * It fetches the submission details, resolves the workflows that should run
-   * for the challenge, and queues them for execution.
-   *
-   * @param submissionBaseService - Service to fetch submission details.
-   * @param challengeApiService - Service to fetch challenge details for legacy workflow fallback.
-   * @param workflowQueueHandler - Service that persists and schedules workflow runs.
-   * @param prisma - Review database service used to resolve the active AI review config.
-   */
   constructor(
-    private readonly submissionBaseService: SubmissionBaseService,
-    private readonly challengeApiService: ChallengeApiService,
-    private readonly workflowQueueHandler: WorkflowQueueHandler,
-    private readonly prisma: PrismaService,
+    private readonly aiWorkflowQueueService: AiWorkflowQueueService,
   ) {}
-
-  /**
-   * Determine whether the challenge has AI workflows configured via the active
-   * AI review config.
-   *
-   * @param challengeId - Challenge identifier associated with the submission.
-   * @returns True when the active AI review config defines at least one workflow.
-   */
-  async hasConfiguredAiReviewWorkflows(challengeId: string): Promise<boolean> {
-    const configured = await this.getConfiguredAiWorkflowIds(challengeId);
-    return configured?.mode === 'queue' && configured.workflowIds.length > 0;
-  }
 
   async orchestrateScanComplete(submissionId: string): Promise<void> {
     this.logger.log(
       `Orchestrating scan complete for submission ID: ${submissionId}`,
     );
+
     try {
-      const submission: SubmissionResponseDto =
-        await this.submissionBaseService.getSubmissionById(submissionId);
-      this.logger.log(`Submission details: ${JSON.stringify(submission)}`);
-
-      const challengeId = String(submission.challengeId ?? '').trim();
-      if (!challengeId) {
-        this.logger.warn(
-          `Skipping AI workflow queueing because submission ${submissionId} is missing challengeId.`,
-        );
-        return;
-      }
-
-      const workflowIds = await this.getWorkflowIdsForScanComplete(challengeId);
-      if (!workflowIds.length) {
-        // no ai workflow defined for challenge, return
-        return;
-      }
-
-      await this.workflowQueueHandler.queueWorkflowRuns(
-        workflowIds.map((id) => ({ id })),
-        challengeId,
+      await this.aiWorkflowQueueService.queueWorkflowsForSubmission(
         submissionId,
       );
     } catch (error) {
@@ -80,109 +32,5 @@ export class SubmissionScanCompleteOrchestrator {
       );
       throw error;
     }
-  }
-
-  /**
-   * Resolve the workflow ids that should run after a clean scan completes.
-   * AI review config is the primary source of truth, with challenge-linked
-   * workflows preserved as a fallback for legacy flows.
-   *
-   * @param challengeId - Challenge identifier associated with the submission.
-   * @returns Workflow ids that should be queued for the submission.
-   */
-  private async getWorkflowIdsForScanComplete(
-    challengeId: string,
-  ): Promise<string[]> {
-    const configured = await this.getConfiguredAiWorkflowIds(challengeId);
-    if (configured?.mode === 'queue') {
-      return configured.workflowIds;
-    }
-    if (configured?.mode === 'skip') {
-      return [];
-    }
-
-    const challenge =
-      await this.challengeApiService.getChallengeDetail(challengeId);
-    this.logger.log(`Challenge details: ${JSON.stringify(challenge)}`);
-
-    return Array.from(
-      new Set(
-        (challenge.workflows ?? [])
-          .map((workflow) => workflow.id)
-          .filter((workflowId): workflowId is string => Boolean(workflowId)),
-      ),
-    );
-  }
-
-  /**
-   * Resolve workflow ids from the latest AI review config for a challenge.
-   *
-   * @param challengeId - Challenge identifier associated with the submission.
-   * @returns Workflow ids declared on the active AI review config.
-   */
-  private async getConfiguredAiWorkflowIds(
-    challengeId: string,
-  ): Promise<
-    | { mode: 'queue'; workflowIds: string[] }
-    | { mode: 'skip' }
-    | { mode: 'fallback' }
-  > {
-    if (!challengeId) {
-      return { mode: 'fallback' };
-    }
-
-    const config = await this.prisma.aiReviewConfig.findFirst({
-      where: { challengeId },
-      orderBy: { version: 'desc' },
-      select: {
-        template: {
-          select: {
-            disabled: true,
-          },
-        },
-        instantReview: true,
-        workflows: {
-          where: {
-            workflow: {
-              disabled: false,
-            },
-          },
-          select: { workflowId: true },
-        },
-      },
-    });
-
-    if (!config) {
-      return { mode: 'fallback' };
-    }
-
-    if (config.template?.disabled) {
-      this.logger.warn(
-        `Skipping AI workflow queueing for challenge ${challengeId} because linked template is disabled.`,
-      );
-      return { mode: 'skip' };
-    }
-
-    if (config.instantReview !== true) {
-      this.logger.log(
-        `Skipping AI workflow queueing for challenge ${challengeId} because instantReview is disabled.`,
-      );
-      return { mode: 'skip' };
-    }
-
-    return {
-      mode: 'queue',
-      workflowIds: Array.from(
-        new Set(
-          (config.workflows ?? [])
-            .map((workflow: { workflowId?: unknown }) =>
-              typeof workflow.workflowId === 'string'
-                ? workflow.workflowId
-                : undefined,
-            )
-            .filter((workflowId): workflowId is string => Boolean(workflowId)),
-        ),
-      ),
-    };
   }
 }

--- a/src/shared/modules/global/submission-scan-complete.orchestrator.ts
+++ b/src/shared/modules/global/submission-scan-complete.orchestrator.ts
@@ -41,8 +41,8 @@ export class SubmissionScanCompleteOrchestrator {
    * @returns True when the active AI review config defines at least one workflow.
    */
   async hasConfiguredAiReviewWorkflows(challengeId: string): Promise<boolean> {
-    const workflowIds = await this.getConfiguredAiWorkflowIds(challengeId);
-    return workflowIds.length > 0;
+    const configured = await this.getConfiguredAiWorkflowIds(challengeId);
+    return configured?.mode === 'queue' && configured.workflowIds.length > 0;
   }
 
   async orchestrateScanComplete(submissionId: string): Promise<void> {
@@ -93,10 +93,12 @@ export class SubmissionScanCompleteOrchestrator {
   private async getWorkflowIdsForScanComplete(
     challengeId: string,
   ): Promise<string[]> {
-    const configuredWorkflowIds =
-      await this.getConfiguredAiWorkflowIds(challengeId);
-    if (configuredWorkflowIds.length) {
-      return configuredWorkflowIds;
+    const configured = await this.getConfiguredAiWorkflowIds(challengeId);
+    if (configured?.mode === 'queue') {
+      return configured.workflowIds;
+    }
+    if (configured?.mode === 'skip') {
+      return [];
     }
 
     const challenge =
@@ -120,9 +122,13 @@ export class SubmissionScanCompleteOrchestrator {
    */
   private async getConfiguredAiWorkflowIds(
     challengeId: string,
-  ): Promise<string[]> {
+  ): Promise<
+    | { mode: 'queue'; workflowIds: string[] }
+    | { mode: 'skip' }
+    | { mode: 'fallback' }
+  > {
     if (!challengeId) {
-      return [];
+      return { mode: 'fallback' };
     }
 
     const config = await this.prisma.aiReviewConfig.findFirst({
@@ -134,6 +140,7 @@ export class SubmissionScanCompleteOrchestrator {
             disabled: true,
           },
         },
+        instantReview: true,
         workflows: {
           where: {
             workflow: {
@@ -145,23 +152,37 @@ export class SubmissionScanCompleteOrchestrator {
       },
     });
 
-    if (config?.template?.disabled) {
+    if (!config) {
+      return { mode: 'fallback' };
+    }
+
+    if (config.template?.disabled) {
       this.logger.warn(
         `Skipping AI workflow queueing for challenge ${challengeId} because linked template is disabled.`,
       );
-      return [];
+      return { mode: 'skip' };
     }
 
-    return Array.from(
-      new Set(
-        (config?.workflows ?? [])
-          .map((workflow: { workflowId?: unknown }) =>
-            typeof workflow.workflowId === 'string'
-              ? workflow.workflowId
-              : undefined,
-          )
-          .filter((workflowId): workflowId is string => Boolean(workflowId)),
+    if (config.instantReview !== true) {
+      this.logger.log(
+        `Skipping AI workflow queueing for challenge ${challengeId} because instantReview is disabled.`,
+      );
+      return { mode: 'skip' };
+    }
+
+    return {
+      mode: 'queue',
+      workflowIds: Array.from(
+        new Set(
+          (config.workflows ?? [])
+            .map((workflow: { workflowId?: unknown }) =>
+              typeof workflow.workflowId === 'string'
+                ? workflow.workflowId
+                : undefined,
+            )
+            .filter((workflowId): workflowId is string => Boolean(workflowId)),
+        ),
       ),
-    );
+    };
   }
 }

--- a/src/shared/modules/kafka/handlers/ai-phase-opened.handler.spec.ts
+++ b/src/shared/modules/kafka/handlers/ai-phase-opened.handler.spec.ts
@@ -1,6 +1,16 @@
 import { AiPhaseOpenedHandler } from './ai-phase-opened.handler';
 
 describe('AiPhaseOpenedHandler', () => {
+  const originalDispatchAiReviewWorkflows =
+    process.env.DISPATCH_AI_REVIEW_WORKFLOWS;
+  afterEach(() => {
+    if (originalDispatchAiReviewWorkflows === undefined) {
+      delete process.env.DISPATCH_AI_REVIEW_WORKFLOWS;
+    } else {
+      process.env.DISPATCH_AI_REVIEW_WORKFLOWS =
+        originalDispatchAiReviewWorkflows;
+    }
+  });
   const handlerRegistryMock = {
     registerHandler: jest.fn(),
   };

--- a/src/shared/modules/kafka/handlers/ai-phase-opened.handler.spec.ts
+++ b/src/shared/modules/kafka/handlers/ai-phase-opened.handler.spec.ts
@@ -1,0 +1,44 @@
+import { AiPhaseOpenedHandler } from './ai-phase-opened.handler';
+
+describe('AiPhaseOpenedHandler', () => {
+  const handlerRegistryMock = {
+    registerHandler: jest.fn(),
+  };
+  const orchestratorMock = {
+    orchestrateChallengePhaseOpened: jest.fn(),
+  };
+  let handler: AiPhaseOpenedHandler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = new AiPhaseOpenedHandler(
+      handlerRegistryMock as any,
+      orchestratorMock as any,
+    );
+  });
+
+  it('registers itself on module init', () => {
+    handler.onModuleInit();
+
+    expect(handlerRegistryMock.registerHandler).toHaveBeenCalledWith(
+      'autopilot.ai.phase.opened',
+      handler,
+    );
+  });
+
+  it('processes valid messages and delegates orchestration', async () => {
+    process.env.DISPATCH_AI_REVIEW_WORKFLOWS = 'true';
+    await handler.handle({ payload: { challengeId: 'challenge-1' } });
+
+    expect(orchestratorMock.orchestrateChallengePhaseOpened).toHaveBeenCalledWith(
+      'challenge-1',
+    );
+  });
+
+  it('skips when dispatch is disabled', async () => {
+    process.env.DISPATCH_AI_REVIEW_WORKFLOWS = 'false';
+    await handler.handle({ payload: { challengeId: 'challenge-1' } });
+
+    expect(orchestratorMock.orchestrateChallengePhaseOpened).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/modules/kafka/handlers/ai-phase-opened.handler.ts
+++ b/src/shared/modules/kafka/handlers/ai-phase-opened.handler.ts
@@ -1,0 +1,63 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { KafkaHandlerRegistry } from '../kafka-handler.registry';
+import { BaseEventHandler } from '../base-event.handler';
+import { LoggerService } from '../../global/logger.service';
+import { AiPhaseOpenedOrchestrator } from '../../global/ai-phase-opened.orchestrator';
+
+@Injectable()
+export class AiPhaseOpenedHandler
+  extends BaseEventHandler
+  implements OnModuleInit
+{
+  private readonly topic = 'autopilot.ai.phase.opened';
+
+  constructor(
+    private readonly handlerRegistry: KafkaHandlerRegistry,
+    private readonly orchestrator: AiPhaseOpenedOrchestrator,
+  ) {
+    super(LoggerService.forRoot('AiPhaseOpenedHandler'));
+  }
+
+  onModuleInit() {
+    this.handlerRegistry.registerHandler(this.topic, this);
+    this.logger.log(`Registered handler for topic: ${this.topic}`);
+  }
+
+  getTopic(): string {
+    return this.topic;
+  }
+
+  async handle(message: any): Promise<void> {
+    try {
+      this.logger.log({
+        message: 'Processing AI phase opened event',
+        topic: this.topic,
+        payload: message,
+      });
+
+      if (!this.validateMessage(message)) {
+        this.logger.warn('Invalid message received');
+        return;
+      }
+
+      const challengeId = String(message.payload?.challengeId ?? '').trim();
+      if (!challengeId) {
+        this.logger.warn('AI phase opened event missing challengeId; skipping.');
+        return;
+      }
+
+      if (process.env.DISPATCH_AI_REVIEW_WORKFLOWS !== 'true') {
+        this.logger.log(
+          'AI workflow dispatch is disabled. Skipping AI phase opened orchestration.',
+        );
+        return;
+      }
+
+      await this.orchestrator.orchestrateChallengePhaseOpened(challengeId);
+      this.logger.log('AI phase opened event processed successfully');
+    } catch (error) {
+      this.logger.error('Error processing AI phase opened event', error);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces support for an "instant review" feature in the AI review workflow system, allowing AI review workflows to be dispatched immediately after scan completion or at the opening of an AI phase. It includes changes to the database schema, application logic, DTOs, and adds new orchestrator and queueing services with accompanying tests.

**Instant Review Feature Integration:**

- **Database and Model Updates:**
  - Added a new `instantReview` boolean column to the `aiReviewConfig` table and corresponding Prisma model to indicate whether instant AI review should be triggered (`prisma/migrations/20260608120000_add_instant_review_flag/migration.sql`, `prisma/schema.prisma`).

- **DTO and Service Layer Changes:**
  - Updated DTOs (`CreateAiReviewConfigDto`, `AiReviewConfigResponseDto`) and service logic (`AiReviewConfigService`) to support the new `instantReview` property, ensuring it is handled in creation, update, and response flows (`src/dto/aiReviewConfig.dto.ts`, `src/api/ai-review-config/ai-review-config.service.ts`).

**AI Workflow Queueing and Orchestration:**

- **New AI Workflow Queue Service:**
  - Implemented `AiWorkflowQueueService` to handle logic for determining and queuing AI workflows for submissions, respecting the `instantReview` flag and falling back to challenge-linked workflows if no config exists (`src/shared/modules/global/ai-workflow-queue.service.ts`).

- **AI Phase Opened Orchestrator:**
  - Added `AiPhaseOpenedOrchestrator` to orchestrate queueing of AI workflows for the latest submissions when an AI phase is opened, with robust error handling and logging (`src/shared/modules/global/ai-phase-opened.orchestrator.ts`).
  - 
