### PR TITLE
PM-5716: prevent scan-created approval reviews

### DIFF
--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -3838,6 +3838,104 @@ describe('SubmissionService', () => {
       );
     });
 
+    it('skips approval pending creation because autopilot owns winner selection', async () => {
+      const prismaMock = {
+        submission: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'submission-approval',
+            challengeId: 'challenge-approval',
+            type: SubmissionType.CONTEST_SUBMISSION,
+            virusScan: true,
+          }),
+        },
+        scorecard: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              id: 'scorecard-approval',
+              type: ScorecardType.APPROVAL,
+            },
+          ]),
+        },
+        reviewType: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              id: 'review-type-approval',
+              name: 'Approval',
+            },
+          ]),
+        },
+        review: {
+          createMany: jest.fn(),
+        },
+        aiReviewDecision: {
+          findFirst: jest.fn(),
+        },
+      };
+      const challengePrismaMock = {
+        $queryRaw: jest.fn().mockResolvedValue([
+          {
+            scorecardId: 'scorecard-approval',
+            templatePhaseId: 'phase-template-approval',
+            challengePhaseId: 'challenge-phase-approval',
+            phaseName: 'Approval',
+          },
+        ]),
+      };
+      const challengeApiServiceMock = {
+        getChallengeDetail: jest.fn().mockResolvedValue({
+          id: 'challenge-approval',
+          phases: [
+            {
+              id: 'challenge-phase-approval',
+              name: 'Approval',
+              isOpen: true,
+            },
+          ],
+        }),
+      };
+      const resourceApiServiceMock = {
+        getResources: jest.fn().mockResolvedValue([
+          {
+            id: 'resource-approver',
+            challengeId: 'challenge-approval',
+            memberId: '2002',
+            memberHandle: 'approverOne',
+            roleId: 'role-approver',
+            phaseId: 'challenge-phase-approval',
+            createdBy: 'system',
+            created: new Date().toISOString(),
+          },
+        ]),
+        getResourceRoles: jest.fn().mockResolvedValue({
+          'role-approver': {
+            id: 'role-approver',
+            name: 'Approver',
+          },
+        }),
+      };
+
+      const pendingReviewService = new SubmissionService(
+        prismaMock as any,
+        {} as any,
+        challengePrismaMock as any,
+        challengeApiServiceMock as any,
+        resourceApiServiceMock as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+
+      const created =
+        await pendingReviewService.ensurePendingReviewsForSubmission(
+          'submission-approval',
+          { triggerSource: 'scan-complete' },
+        );
+
+      expect(created).toBe(0);
+      expect(prismaMock.review.createMany).not.toHaveBeenCalled();
+    });
+
     it('skips pending review creation when AI pass is required but decision is failed', async () => {
       const prismaMock = {
         submission: {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -2666,7 +2666,6 @@ export class SubmissionService {
       'review',
       'checkpoint review',
       'iterative review',
-      'approval',
     ]).has(normalizedPhaseName);
   }
 


### PR DESCRIPTION
## What was broken

Delayed clean-scan events could create Approval reviews for every submission while Approval was open, including submissions that failed Review. The extra pending rows appeared in the Approval tab and could keep the phase open.

## Root cause

The Review API's generic pending-review path treated Approval as a per-submission phase, even though Autopilot owns Approval candidate selection and chooses the highest passing submission.

## What was changed

Excluded Approval from generic scan-driven pending-review creation so only Autopilot creates Approval assignments. Existing multi-approver assignment and visibility behavior remains unchanged.

## Any added/updated tests

Added a SubmissionService regression test proving an open Approval phase does not receive review rows from the scan-complete path.

The focused regression test, lint, and build pass. The full suite was also run: this branch has 260 passing tests and seven unrelated failures already present on `origin/develop`; an untouched base snapshot has 259 passing tests and the same seven failures.
