### PR TITLE
PM-5471: add reviewer role filtering to my reviews

### DIFF
--- a/src/api/my-review/myReview.controller.ts
+++ b/src/api/my-review/myReview.controller.ts
@@ -69,6 +69,12 @@ export class MyReviewController {
     enum: ChallengeStatus,
   })
   @ApiQuery({
+    name: 'resourceRoleIds',
+    required: false,
+    description:
+      'Comma-separated resource role identifiers assigned to the requesting member',
+  })
+  @ApiQuery({
     name: 'past',
     required: false,
     description:

--- a/src/api/my-review/myReview.service.spec.ts
+++ b/src/api/my-review/myReview.service.spec.ts
@@ -231,6 +231,126 @@ describe('MyReviewService', () => {
     expect(queryDetails.values).toContain(ChallengeStatus.COMPLETED);
   });
 
+  it('pages role-filtered past reviews by distinct challenge before restoring resource rows', async () => {
+    challengePrismaMock.$queryRaw
+      .mockResolvedValueOnce([{ total: 1n }])
+      .mockResolvedValueOnce([]);
+
+    await service.getMyReviews(
+      { isMachine: false, userId: '151743' },
+      {
+        past: 'true',
+        resourceRoleIds:
+          ' reviewer-role-id, ,screener-role-id,reviewer-role-id, ',
+      },
+      { page: 1, perPage: 50 },
+    );
+
+    const [countQuery, rowQuery] = challengePrismaMock.$queryRaw.mock.calls.map(
+      (call) => call[0],
+    );
+
+    [countQuery, rowQuery].forEach((query) => {
+      const queryDetails = query.inspect();
+      const sql = queryDetails.sql.replace(/\s+/g, ' ');
+      const requestedRoleValues = queryDetails.values.filter(
+        (value) => value === 'reviewer-role-id' || value === 'screener-role-id',
+      );
+
+      expect(sql).toContain('r."roleId" IN (?, ?)');
+      expect(requestedRoleValues).toEqual([
+        'reviewer-role-id',
+        'screener-role-id',
+      ]);
+      expect(queryDetails.values).not.toContain('');
+    });
+
+    const countSql = countQuery.inspect().sql.replace(/\s+/g, ' ');
+    const rowSql = rowQuery.inspect().sql.replace(/\s+/g, ' ');
+    const limitPosition = rowSql.indexOf('LIMIT ?');
+    const finalResourceJoinPosition = rowSql.indexOf('JOIN base_matches bm');
+
+    expect(countSql).toContain('SELECT COUNT(DISTINCT c.id) AS "total"');
+    expect(rowSql).toContain('challenge_page AS MATERIALIZED');
+    expect(rowSql).toContain('SELECT DISTINCT "challengeId"');
+    expect(limitPosition).toBeGreaterThan(-1);
+    expect(finalResourceJoinPosition).toBeGreaterThan(limitPosition);
+  });
+
+  it('filters member-ordered past reviews by the requested resource roles', async () => {
+    challengePrismaMock.$queryRaw
+      .mockResolvedValueOnce([{ total: 1n }])
+      .mockResolvedValueOnce([]);
+
+    await service.getMyReviews(
+      { isMachine: false, userId: '151743' },
+      {
+        past: 'true',
+        resourceRoleIds: 'reviewer-role-id,screener-role-id',
+        sortBy: 'challengeName',
+      },
+      { page: 1, perPage: 50 },
+    );
+
+    const rowQuery = challengePrismaMock.$queryRaw.mock.calls[1][0];
+    const queryDetails = rowQuery.inspect();
+    const sql = queryDetails.sql.replace(/\s+/g, ' ');
+
+    expect(sql).toContain('base_matches AS MATERIALIZED');
+    expect(sql).toContain('challenge_page AS MATERIALIZED');
+    expect(sql.indexOf('LIMIT ?')).toBeLessThan(
+      sql.indexOf('JOIN base_matches bm'),
+    );
+    expect(sql).toContain('r."roleId" IN (?, ?)');
+    expect(queryDetails.values).toEqual(
+      expect.arrayContaining(['reviewer-role-id', 'screener-role-id']),
+    );
+  });
+
+  it('joins member resources in the admin count query when filtering by role', async () => {
+    challengePrismaMock.$queryRaw.mockResolvedValueOnce([{ total: 0n }]);
+
+    await service.getMyReviews(
+      { isMachine: true, userId: 'admin-member-id' },
+      { resourceRoleIds: 'reviewer-role-id' },
+    );
+
+    const countQuery = challengePrismaMock.$queryRaw.mock.calls[0][0];
+    const queryDetails = countQuery.inspect();
+    const sql = queryDetails.sql.replace(/\s+/g, ' ');
+
+    expect(sql).toContain('LEFT JOIN resources."Resource" r');
+    expect(sql).toContain('r."memberId" = ?');
+    expect(sql).toContain('r."roleId" IN (?)');
+    expect(queryDetails.values).toEqual(
+      expect.arrayContaining(['admin-member-id', 'reviewer-role-id']),
+    );
+  });
+
+  it('uses challenge-level pagination for an admin past-role filter', async () => {
+    challengePrismaMock.$queryRaw
+      .mockResolvedValueOnce([{ total: 1n }])
+      .mockResolvedValueOnce([]);
+
+    await service.getMyReviews(
+      { isMachine: true, userId: 'admin-member-id' },
+      { past: 'true', resourceRoleIds: 'reviewer-role-id' },
+      { page: 1, perPage: 50 },
+    );
+
+    const [countQuery, rowQuery] = challengePrismaMock.$queryRaw.mock.calls.map(
+      (call) => call[0],
+    );
+    const countSql = countQuery.inspect().sql.replace(/\s+/g, ' ');
+    const rowSql = rowQuery.inspect().sql.replace(/\s+/g, ' ');
+
+    expect(countSql).toContain('SELECT COUNT(DISTINCT c.id) AS "total"');
+    expect(rowSql).toContain('challenge_page AS MATERIALIZED');
+    expect(rowSql.indexOf('LIMIT ?')).toBeLessThan(
+      rowSql.indexOf('JOIN base_matches bm'),
+    );
+  });
+
   it('uses a paged base query for past member challenge end sorting', async () => {
     challengePrismaMock.$queryRaw
       .mockResolvedValueOnce([{ total: 1n }])
@@ -245,9 +365,14 @@ describe('MyReviewService', () => {
     const query = challengePrismaMock.$queryRaw.mock.calls[1][0];
     const queryDetails = query.inspect();
     const sql = queryDetails.sql.replace(/\s+/g, ' ');
+    const countSql = challengePrismaMock.$queryRaw.mock.calls[0][0]
+      .inspect()
+      .sql.replace(/\s+/g, ' ');
 
+    expect(countSql).toContain('SELECT COUNT(*) AS "total"');
     expect(sql).toContain('base_page AS MATERIALIZED');
     expect(sql).toContain('JOIN LATERAL');
+    expect(sql).not.toContain('challenge_page AS MATERIALIZED');
     expect(sql).not.toContain('COUNT(*) OVER() AS "totalCount"');
     expect(sql).toContain('ORDER BY c."endDate" DESC NULLS LAST');
     expect(sql).toContain('ORDER BY bp."challengeEndDate" DESC NULLS LAST');

--- a/src/api/my-review/myReview.service.ts
+++ b/src/api/my-review/myReview.service.ts
@@ -98,6 +98,14 @@ export class MyReviewService {
     const challengeTrackId = filters.challengeTrackId?.trim();
     const challengeTypeName = filters.challengeTypeName?.trim();
     const challengeName = filters.challengeName?.trim();
+    const resourceRoleIds = Array.from(
+      new Set(
+        (filters.resourceRoleIds ?? '')
+          .split(',')
+          .map((roleId) => roleId.trim())
+          .filter(Boolean),
+      ),
+    );
     const normalizedChallengeStatus = filters.challengeStatus
       ? filters.challengeStatus.trim().toUpperCase()
       : undefined;
@@ -128,6 +136,17 @@ export class MyReviewService {
       filters.sortOrder?.toLowerCase() === 'desc' ? 'desc' : 'asc';
 
     const whereFragments: Prisma.Sql[] = [];
+
+    if (resourceRoleIds.length) {
+      const resourceRoleIdFragments = resourceRoleIds.map(
+        (roleId) => Prisma.sql`${roleId}`,
+      );
+      const resourceRoleIdList = joinSqlFragments(
+        resourceRoleIdFragments,
+        Prisma.sql`, `,
+      );
+      whereFragments.push(Prisma.sql`r."roleId" IN (${resourceRoleIdList})`);
+    }
 
     if (shouldFetchPastChallenges) {
       if (normalizedChallengeStatus) {
@@ -295,15 +314,21 @@ export class MyReviewService {
         `,
       );
     } else {
-      baseJoins.push(
-        Prisma.sql`
+      const adminResourceJoin = Prisma.sql`
           LEFT JOIN resources."Resource" r
             ON r."challengeId" = c.id
            AND ${normalizedUserId} IS NOT NULL AND r."memberId" = ${normalizedUserId}
+      `;
+      baseJoins.push(
+        adminResourceJoin,
+        Prisma.sql`
           LEFT JOIN resources."ResourceRole" rr
             ON rr.id = r."roleId"
         `,
       );
+      if (resourceRoleIds.length) {
+        countJoins.push(adminResourceJoin);
+      }
     }
 
     baseJoins.push(
@@ -602,9 +627,16 @@ export class MyReviewService {
         `
         : Prisma.sql``;
 
+    const shouldUseRoleFilteredPastQuery =
+      shouldFetchPastChallenges &&
+      resourceRoleIds.length > 0 &&
+      normalizedUserId !== null;
+    const countExpression = shouldUseRoleFilteredPastQuery
+      ? Prisma.sql`COUNT(DISTINCT c.id)`
+      : Prisma.sql`COUNT(*)`;
     const countQuery = Prisma.sql`
       ${countWithClause}
-      SELECT COUNT(*) AS "total"
+      SELECT ${countExpression} AS "total"
       FROM challenges."Challenge" c
       ${countJoinClause}
       WHERE ${countWhereClause}
@@ -614,7 +646,10 @@ export class MyReviewService {
     let totalCount = 0;
     let totalPages = 0;
 
-    if (shouldFetchPastChallenges && !adminUser) {
+    if (
+      shouldFetchPastChallenges &&
+      (!adminUser || shouldUseRoleFilteredPastQuery)
+    ) {
       const countQueryDetails = countQuery.inspect();
       this.logger.debug({
         message: 'Executing past challenge count query',
@@ -639,7 +674,8 @@ export class MyReviewService {
         };
       }
 
-      const shouldUseChallengeOrderedPastQuery = sortBy !== 'challengeName';
+      const shouldUseChallengeOrderedPastQuery =
+        !resourceRoleIds.length && sortBy !== 'challengeName';
       const pastPageSortFragments: Prisma.Sql[] = [];
       const pastFinalSortFragments: Prisma.Sql[] = [];
 
@@ -654,7 +690,9 @@ export class MyReviewService {
           break;
         case 'challengeEndDate':
           pastPageSortFragments.push(
-            Prisma.sql`c."endDate" ${directionSql} NULLS LAST`,
+            shouldUseChallengeOrderedPastQuery
+              ? Prisma.sql`c."endDate" ${directionSql} NULLS LAST`
+              : Prisma.sql`"challengeEndDate" ${directionSql} NULLS LAST`,
           );
           pastFinalSortFragments.push(
             Prisma.sql`bp."challengeEndDate" ${directionSql} NULLS LAST`,
@@ -692,6 +730,40 @@ export class MyReviewService {
           : pastFinalFallbackOrderFragments,
         Prisma.sql`, `,
       );
+      const memberOrderedBasePageCte = resourceRoleIds.length
+        ? Prisma.sql`
+          challenge_page AS MATERIALIZED (
+            SELECT DISTINCT
+              "challengeId",
+              "challengeName",
+              "challengeTypeId",
+              "challengeTypeName",
+              "challengeEndDate",
+              "numOfSubmissions",
+              "challengeCreatedAt",
+              status
+            FROM base_matches
+            ORDER BY ${pastPageOrderClause}
+            LIMIT ${perPage}
+            OFFSET ${offset}
+          ),
+          base_page AS MATERIALIZED (
+            SELECT bm.*
+            FROM challenge_page cp
+            JOIN base_matches bm
+              ON bm."challengeId" = cp."challengeId"
+          )
+        `
+        : Prisma.sql`
+          base_page AS MATERIALIZED (
+            SELECT
+              *
+            FROM base_matches
+            ORDER BY ${pastPageOrderClause}
+            LIMIT ${perPage}
+            OFFSET ${offset}
+          )
+        `;
 
       const rowQuery = shouldUseChallengeOrderedPastQuery
         ? Prisma.sql`
@@ -836,14 +908,7 @@ export class MyReviewService {
               ON ct.id = c."typeId"
             WHERE ${rowWhereClause}
           ),
-          base_page AS MATERIALIZED (
-            SELECT
-              *
-            FROM base_matches
-            ORDER BY ${pastPageOrderClause}
-            LIMIT ${perPage}
-            OFFSET ${offset}
-          )
+          ${memberOrderedBasePageCte}
         SELECT
           bp."challengeId" AS "challengeId",
           bp."challengeName" AS "challengeName",

--- a/src/dto/my-review.dto.ts
+++ b/src/dto/my-review.dto.ts
@@ -88,6 +88,15 @@ export class MyReviewFilterDto {
 
   @ApiProperty({
     description:
+      'Comma-separated resource role identifiers assigned to the requesting member',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  resourceRoleIds?: string;
+
+  @ApiProperty({
+    description:
       'Whether or not to include current challenges or past challenges',
     required: false,
   })


### PR DESCRIPTION
## What was broken

Members could not request only past challenges where they held reviewer resource roles.

## Root cause

The `/my-reviews` contract and SQL did not accept or apply a resource-role filter. Pagination also operated on resource rows, which could duplicate a challenge when a member held multiple requested reviewer roles.

## What was changed

- Added a validated, documented `resourceRoleIds` comma-separated query parameter.
- Applied the requested IDs through parameterized SQL to result and count queries.
- Counted and paged distinct challenges for role-filtered past requests before restoring matching resource rows.
- Preserved the existing unfiltered query paths.
- Added the companion UI in https://github.com/topcoder-platform/platform-ui/pull/2060.

## Any added/updated tests

- Updated `MyReviewService` tests for parsing and deduplication, parameterized role predicates, distinct challenge pagination, admin counting, and unchanged unfiltered behavior.
- `pnpm test --runInBand --silent src/api/my-review/myReview.service.spec.ts`: 14 tests passed.
- `pnpm lint`: passed.
- `pnpm build`: passed.
- Full `pnpm test --runInBand --silent`: the PM-5471 suite passed; the repository retains 7 pre-existing failures in submission and appeal tests, reproduced on clean `origin/develop`.
