### PR TITLE
PM-5738 deterministic ai workflow

### DIFF
--- a/prisma/migrations/20260729120000_add_review_method_to_ai_workflow/migration.sql
+++ b/prisma/migrations/20260729120000_add_review_method_to_ai_workflow/migration.sql
@@ -1,0 +1,5 @@
+-- Add reviewMethod enum and column to aiWorkflow.
+CREATE TYPE "ReviewMethod" AS ENUM ('AI-Assisted', 'Deterministic');
+
+ALTER TABLE "aiWorkflow"
+  ADD COLUMN "reviewMethod" "ReviewMethod" NOT NULL DEFAULT 'AI-Assisted';

--- a/prisma/migrations/20260729120000_add_review_method_to_ai_workflow/migration.sql
+++ b/prisma/migrations/20260729120000_add_review_method_to_ai_workflow/migration.sql
@@ -1,5 +1,5 @@
 -- Add reviewMethod enum and column to aiWorkflow.
-CREATE TYPE "ReviewMethod" AS ENUM ('AI-Assisted', 'Deterministic');
+CREATE TYPE "ReviewMethod" AS ENUM ('AI_ASSISTED', 'DETERMINISTIC');
 
 ALTER TABLE "aiWorkflow"
-  ADD COLUMN "reviewMethod" "ReviewMethod" NOT NULL DEFAULT 'AI-Assisted';
+  ADD COLUMN "reviewMethod" "ReviewMethod" NOT NULL DEFAULT 'AI_ASSISTED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -699,6 +699,11 @@ enum AiReviewDecisionEscalationStatus {
   REJECTED
 }
 
+enum ReviewMethod {
+  AI_ASSISTED      @map("AI-Assisted")
+  DETERMINISTIC   @map("Deterministic")
+}
+
 model aiWorkflow {
   id          String   @id @default(dbgenerated("nanoid()")) @db.VarChar(14)
   name        String   @unique @db.VarChar
@@ -709,6 +714,7 @@ model aiWorkflow {
   gitOwnerRepo  String   @db.VarChar
   scorecardId String   @db.VarChar(14)
   timeoutSeconds Int?   @default(1800)
+  reviewMethod ReviewMethod @default(AI_ASSISTED)
   disabled    Boolean  @default(false)
   createdAt   DateTime @default(now()) @db.Timestamp(3)
   createdBy   String?  @db.Text

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -700,8 +700,8 @@ enum AiReviewDecisionEscalationStatus {
 }
 
 enum ReviewMethod {
-  AI_ASSISTED      @map("AI-Assisted")
-  DETERMINISTIC   @map("Deterministic")
+  AI_ASSISTED
+  DETERMINISTIC
 }
 
 model aiWorkflow {

--- a/src/api/ai-workflow/ai-workflow.service.spec.ts
+++ b/src/api/ai-workflow/ai-workflow.service.spec.ts
@@ -1,0 +1,135 @@
+import { ForbiddenException } from '@nestjs/common';
+import { JwtUser } from 'src/shared/modules/global/jwt.service';
+import { ReviewMethod } from '@prisma/client';
+import type { UpdateAiWorkflowRunItemDto } from 'src/dto/aiWorkflow.dto';
+
+describe('AiWorkflowService.updateRunItem', () => {
+  jest.mock('src/shared/modules/global/prisma.service', () => ({
+    PrismaService: jest.fn(),
+  }));
+  jest.mock('src/shared/modules/global/logger.service', () => ({
+    LoggerService: {
+      forRoot: jest.fn(() => ({
+        log: jest.fn(),
+        error: jest.fn(),
+      })),
+    },
+  }));
+  jest.mock('src/shared/modules/global/challenge.service', () => ({
+    ChallengeApiService: jest.fn(),
+  }));
+  jest.mock('src/shared/modules/global/resource.service', () => ({
+    ResourceApiService: jest.fn(),
+  }));
+  jest.mock('src/shared/modules/global/ai-reviewer-decision-maker.service', () => ({
+    AiReviewerDecisionMakerService: jest.fn(),
+  }));
+  jest.mock('src/shared/modules/global/gitea.service', () => ({
+    GiteaService: jest.fn(),
+  }));
+  jest.mock('src/shared/modules/global/member-prisma.service', () => ({
+    MemberPrismaService: jest.fn(),
+  }));
+  jest.mock('src/shared/modules/global/challenge-prisma.service', () => ({
+    ChallengePrismaService: jest.fn(),
+  }));
+  jest.mock('src/shared/modules/global/workflow-queue.handler', () => ({
+    WorkflowQueueHandler: jest.fn(),
+  }));
+
+  let AiWorkflowService: any;
+  let service: any;
+
+  const prismaMock = {
+    aiWorkflow: {
+      findUnique: jest.fn(),
+    },
+    aiWorkflowRun: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    aiWorkflowRunItem: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    aiWorkflowRunItemVote: {
+      deleteMany: jest.fn(),
+      create: jest.fn(),
+    },
+    aiWorkflowRunItemComment: {
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+    submission: {
+      findUnique: jest.fn(),
+    },
+  } as unknown as any;
+
+  const memberPrismaMock = {} as any;
+  const challengeApiServiceMock = {
+    isPhaseOpen: jest.fn(),
+  } as any;
+  const resourceApiServiceMock = {} as any;
+  const aiReviewerDecisionMakerMock = {
+    evaluateSubmission: jest.fn(),
+  } as any;
+  const giteaServiceMock = {} as any;
+  const workflowQueueHandlerMock = {} as any;
+  const challengePrismaMock = {} as any;
+
+  beforeAll(async () => {
+    const imported = await import('./ai-workflow.service');
+    AiWorkflowService = imported.AiWorkflowService;
+    service = new AiWorkflowService(
+      prismaMock,
+      memberPrismaMock,
+      {} as any,
+      resourceApiServiceMock,
+      aiReviewerDecisionMakerMock,
+      {} as any,
+      giteaServiceMock,
+      workflowQueueHandlerMock,
+      challengePrismaMock,
+    );
+  });
+
+  const user: JwtUser = {
+    userId: 'user-1',
+    roles: [],
+    isMachine: false,
+  };
+
+  const workflowId = 'workflow-1';
+  const runId = 'run-1';
+  const itemId = 'item-1';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    prismaMock.aiWorkflow.findUnique.mockResolvedValue({
+      id: workflowId,
+      reviewMethod: ReviewMethod.DETERMINISTIC,
+    });
+    prismaMock.aiWorkflowRun.findUnique.mockResolvedValue({
+      id: runId,
+      workflowId,
+      submissionId: 'submission-1',
+    });
+    prismaMock.aiWorkflowRunItem.findUnique.mockResolvedValue({
+      id: itemId,
+      workflowRunId: runId,
+      scorecardQuestionId: 'question-1',
+      questionScore: 1,
+      originalQuestionScore: null,
+    });
+  });
+
+  it('throws ForbiddenException when adding a comment to a deterministic workflow via updateRunItem', async () => {
+    const patchData: UpdateAiWorkflowRunItemDto = {
+      comment: 'Looks good',
+    };
+
+    await expect(
+      service.updateRunItem(workflowId, runId, itemId, patchData, user),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -355,6 +355,7 @@ export class AiWorkflowService {
       gitWorkflowId,
       gitOwnerRepo,
       timeoutSeconds,
+      reviewMethod,
     } = createAiWorkflowDto;
 
     const scorecardExists = await this.scorecardExists(scorecardId);
@@ -386,6 +387,7 @@ export class AiWorkflowService {
           scorecardId,
           llmId,
           disabled: createAiWorkflowDto.disabled ?? false,
+          reviewMethod,
           timeoutSeconds,
         },
       })

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -30,7 +30,7 @@ import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
 import { LoggerService } from 'src/shared/modules/global/logger.service';
 import { GiteaService } from 'src/shared/modules/global/gitea.service';
 import { MemberPrismaService } from 'src/shared/modules/global/member-prisma.service';
-import { Prisma, VoteType } from '@prisma/client';
+import { Prisma, ReviewMethod, VoteType } from '@prisma/client';
 import { ChallengePrismaService } from 'src/shared/modules/global/challenge-prisma.service';
 import { WorkflowQueueHandler } from 'src/shared/modules/global/workflow-queue.handler';
 
@@ -165,7 +165,7 @@ export class AiWorkflowService {
         );
       }
 
-      if (workflow.reviewMethod === 'Deterministic') {
+      if (workflow.reviewMethod === ReviewMethod.DETERMINISTIC) {
         throw new ForbiddenException(
           'Comments are disabled for deterministic workflows.',
         );
@@ -292,7 +292,7 @@ export class AiWorkflowService {
       throw new NotFoundException(`Workflow with id ${workflowId} not found.`);
     }
 
-    if (workflow.reviewMethod === 'Deterministic') {
+    if (workflow.reviewMethod === ReviewMethod.DETERMINISTIC) {
       throw new ForbiddenException(
         'Comments are disabled for deterministic workflows.',
       );
@@ -399,7 +399,7 @@ export class AiWorkflowService {
           scorecardId,
           llmId,
           disabled: createAiWorkflowDto.disabled ?? false,
-          reviewMethod,
+          reviewMethod: reviewMethod,
           timeoutSeconds,
         },
       })

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -165,6 +165,12 @@ export class AiWorkflowService {
         );
       }
 
+      if (workflow.reviewMethod === 'Deterministic') {
+        throw new ForbiddenException(
+          'Comments are disabled for deterministic workflows.',
+        );
+      }
+
       const run = await this.prisma.aiWorkflowRun.findUnique({
         where: { id: runId },
       });
@@ -284,6 +290,12 @@ export class AiWorkflowService {
     });
     if (!workflow) {
       throw new NotFoundException(`Workflow with id ${workflowId} not found.`);
+    }
+
+    if (workflow.reviewMethod === 'Deterministic') {
+      throw new ForbiddenException(
+        'Comments are disabled for deterministic workflows.',
+      );
     }
 
     const run = await this.prisma.aiWorkflowRun.findUnique({

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -1245,6 +1245,15 @@ export class AiWorkflowService {
         ? patchData.comment.trim()
         : undefined;
 
+    if (
+      commentText &&
+      workflow.reviewMethod === ReviewMethod.DETERMINISTIC
+    ) {
+      throw new ForbiddenException(
+        'Comments are disabled for deterministic workflows.',
+      );
+    }
+
     let runScore: number | null = null;
 
     if (scoreUpdateRequested) {

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -766,13 +766,44 @@ export class AiWorkflowService {
       },
     });
 
+    const runIds = runs.map((run) => run.id);
+    const commentCounts =
+      runIds.length > 0
+        ? await this.prisma.$queryRaw<
+            Array<{ workflowRunId: string; count: bigint }>
+          >(
+            Prisma.sql`
+              SELECT "aiWorkflowRunItem"."workflowRunId" AS "workflowRunId",
+                    COUNT(*) AS "count"
+              FROM "aiWorkflowRunItemComment"
+              INNER JOIN "aiWorkflowRunItem"
+                ON "aiWorkflowRunItemComment"."workflowRunItemId" = "aiWorkflowRunItem"."id"
+              WHERE "aiWorkflowRunItem"."workflowRunId" IN (${Prisma.join(runIds)})
+              GROUP BY "aiWorkflowRunItem"."workflowRunId"
+            `,
+          )
+        : [];
+
+    const commentCountMap = commentCounts.reduce(
+      (acc, entry) => {
+        acc[entry.workflowRunId] = Number(entry.count);
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    const runsWithCommentCount = runs.map((run) => ({
+      ...run,
+      commentsCount: commentCountMap[run.id] ?? 0,
+    }));
+
     if (filter.runId && !runs.length) {
       throw new NotFoundException(
         `AI Workflow run with id ${filter.runId} not found!`,
       );
     }
 
-    const submission = runs[0]?.submission;
+    const submission = runsWithCommentCount[0]?.submission;
     if ((!submission || !submission.challengeId) && filter.submissionId) {
       this.logger.log(
         `No runs have been found for submission ${filter.submissionId}`,
@@ -830,7 +861,7 @@ export class AiWorkflowService {
       }
     }
 
-    return runs.map((r) => ({ ...r, submission: undefined }));
+    return runsWithCommentCount.map((r) => ({ ...r, submission: undefined }));
   }
 
   async updateWorkflowRun(

--- a/src/api/ai-workflow/ai-workflow.service.ts
+++ b/src/api/ai-workflow/ai-workflow.service.ts
@@ -399,7 +399,7 @@ export class AiWorkflowService {
           scorecardId,
           llmId,
           disabled: createAiWorkflowDto.disabled ?? false,
-          reviewMethod: reviewMethod,
+          reviewMethod,
           timeoutSeconds,
         },
       })

--- a/src/dto/aiWorkflow.dto.ts
+++ b/src/dto/aiWorkflow.dto.ts
@@ -20,14 +20,10 @@ import {
   IsEnum,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
+import { ReviewMethod } from '@prisma/client';
 
 const trimTransformer = ({ value }: { value: unknown }): string | undefined =>
   typeof value === 'string' ? value.trim() : undefined;
-
-export enum ReviewMethod {
-  AI_ASSISTED = 'AI-Assisted',
-  DETERMINISTIC = 'Deterministic',
-}
 
 export class CreateAiWorkflowDto {
   @ApiProperty()

--- a/src/dto/aiWorkflow.dto.ts
+++ b/src/dto/aiWorkflow.dto.ts
@@ -17,11 +17,17 @@ import {
   Max,
   IsEmpty,
   IsBoolean,
+  IsEnum,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 
 const trimTransformer = ({ value }: { value: unknown }): string | undefined =>
   typeof value === 'string' ? value.trim() : undefined;
+
+export enum ReviewMethod {
+  AI_ASSISTED = 'AI-Assisted',
+  DETERMINISTIC = 'Deterministic',
+}
 
 export class CreateAiWorkflowDto {
   @ApiProperty()
@@ -67,6 +73,11 @@ export class CreateAiWorkflowDto {
   @IsOptional()
   @IsBoolean()
   disabled?: boolean;
+
+  @ApiProperty({ required: false, enum: ReviewMethod, default: ReviewMethod.AI_ASSISTED })
+  @IsOptional()
+  @IsEnum(ReviewMethod)
+  reviewMethod?: ReviewMethod;
 
   @ApiProperty({ required: false, default: 1800, minimum: 30 })
   @IsOptional()

--- a/src/shared/modules/global/ai-phase-opened.orchestrator.spec.ts
+++ b/src/shared/modules/global/ai-phase-opened.orchestrator.spec.ts
@@ -54,6 +54,19 @@ describe('AiPhaseOpenedOrchestrator', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('queries only submissions that have passed virus scan', async () => {
+    prismaMock.$queryRaw.mockResolvedValueOnce([{ id: 'submission-1' }]);
+
+    await orchestrator.orchestrateChallengePhaseOpened('challenge-1');
+
+    expect(prismaMock.$queryRaw).toHaveBeenCalled();
+    const query = prismaMock.$queryRaw.mock.calls[0][0];
+    expect(String(query)).toContain('"virusScan" = TRUE');
+    expect(
+      aiWorkflowQueueServiceMock.queueWorkflowsForSubmission,
+    ).toHaveBeenCalledWith('submission-1', { aiPhaseOpened: true });
+  });
+
   it('skips when there are no latest submissions', async () => {
     prismaMock.$queryRaw.mockResolvedValueOnce([]);
 

--- a/src/shared/modules/global/ai-phase-opened.orchestrator.ts
+++ b/src/shared/modules/global/ai-phase-opened.orchestrator.ts
@@ -73,6 +73,7 @@ export class AiPhaseOpenedOrchestrator {
         FROM ${Prisma.sql`"submission"`} s
         WHERE s."challengeId" = ${challengeId}
           AND (s."status" = 'ACTIVE' OR s."status" IS NULL)
+          AND s."virusScan" = TRUE
           AND (
             s."type" IS NULL
             OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'


### PR DESCRIPTION
This pull request introduces a new `reviewMethod` field to the `aiWorkflow` model, allowing workflows to be classified as either `AI_ASSISTED` or `DETERMINISTIC`. It enforces business logic to disable comments for deterministic workflows and updates the API and database schema accordingly. Additionally, it enhances the workflow run listing by including comment counts for each run.

**Database and Schema Updates:**
* Added a new `ReviewMethod` enum and `reviewMethod` column to the `aiWorkflow` table, defaulting to `AI_ASSISTED` [[1]](diffhunk://#diff-269bf3d677b4e01dc5d12e3c9e439af0651c85a8de29a7d5c7390a27d6f33ddcR1-R5) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR702-R706) [[3]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR717).

**API and DTO Enhancements:**
* Updated `CreateAiWorkflowDto` to support the `reviewMethod` field, including validation and OpenAPI documentation [[1]](diffhunk://#diff-885ff0db88ca57b75d660ad296b118f152655f8ff1ab50e9aa032f0d407906a8R20-R23) [[2]](diffhunk://#diff-885ff0db88ca57b75d660ad296b118f152655f8ff1ab50e9aa032f0d407906a8R73-R77).
* Modified workflow creation logic to persist the `reviewMethod` value [[1]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11R370) [[2]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11R402).

**Business Logic Changes:**
* Enforced a restriction that disables comments for workflows with `reviewMethod` set to `DETERMINISTIC`, throwing a `ForbiddenException` when comments are attempted [[1]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11R168-R173) [[2]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11R295-R300).

**API Response Improvements:**
* Enhanced the workflow run listing endpoint to include a `commentsCount` property for each run, aggregating comment counts efficiently [[1]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11R769-R806) [[2]](diffhunk://#diff-bea6290b3b408efcd343dfe7f510c8fed6f8eea088a30b443490e8838b184a11L819-R864).