### PR TITLE
PM-5754: remove duplicate Design download gate

### DIFF
--- a/src/api/submission/submission.controller.ts
+++ b/src/api/submission/submission.controller.ts
@@ -405,7 +405,7 @@ export class SubmissionController {
   @ApiOperation({
     summary: 'Download the submission',
     description:
-      'Roles: Copilot, Admin, User, Reviewer. After challenge completion, the exact metadata value allowAllRegistrantsToDownloadWinningSubmissions=true lets every registered Submitter download only an exact final winning submission and denies non-winners without legacy fallback. Other values retain legacy passing or First2Finish eligibility. Design challenges also require submissionsViewable. | Scopes: read:submission',
+      'Roles: Copilot, Admin, User, Reviewer. After challenge completion, the exact metadata value allowAllRegistrantsToDownloadWinningSubmissions=true lets every registered Submitter download only an exact final winning submission and denies non-winners without legacy fallback. Other values retain legacy passing or First2Finish eligibility. | Scopes: read:submission',
   })
   @ApiParam({
     name: 'submissionId',

--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -1269,7 +1269,7 @@ describe('SubmissionService', () => {
       expect(s3Send).not.toHaveBeenCalled();
     });
 
-    it('lets the Design visibility gate block registrants even when the new flag is enabled', async () => {
+    it('allows all Design registrants to download winner submissions when legacy visibility is disabled', async () => {
       resourceApiService.getMemberResourcesRoles.mockResolvedValue([
         { roleName: 'Submitter' },
       ]);
@@ -1278,66 +1278,6 @@ describe('SubmissionService', () => {
         track: 'Design',
         metadata: {
           submissionsViewable: 'false',
-          allowAllRegistrantsToDownloadWinningSubmissions: 'true',
-        },
-        winners: [{ userId: 'owner-user', placement: 1 }],
-      });
-      prismaMock.submission.findFirst.mockResolvedValue({ id: 'passing-sub' });
-
-      await expect(
-        service.getSubmissionFileStream(
-          {
-            userId: 'registered-user',
-            isMachine: false,
-            roles: [],
-          } as any,
-          'sub-123',
-        ),
-      ).rejects.toBeInstanceOf(ForbiddenException);
-
-      expect(prismaMock.submission.findFirst).not.toHaveBeenCalled();
-      expect(s3Send).not.toHaveBeenCalled();
-    });
-
-    it('applies the Design visibility gate to legacy Design tracks', async () => {
-      resourceApiService.getMemberResourcesRoles.mockResolvedValue([
-        { roleName: 'Submitter' },
-      ]);
-      challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
-        status: ChallengeStatus.COMPLETED,
-        track: 'Legacy',
-        legacy: { track: 'DESIGN' },
-        metadata: {
-          submissionsViewable: 'false',
-          allowAllRegistrantsToDownloadWinningSubmissions: 'true',
-        },
-        winners: [{ userId: 'owner-user', placement: 1 }],
-      });
-
-      await expect(
-        service.getSubmissionFileStream(
-          {
-            userId: 'registered-user',
-            isMachine: false,
-            roles: [],
-          } as any,
-          'sub-123',
-        ),
-      ).rejects.toBeInstanceOf(ForbiddenException);
-
-      expect(prismaMock.submission.findFirst).not.toHaveBeenCalled();
-      expect(s3Send).not.toHaveBeenCalled();
-    });
-
-    it('allows all Design registrants to download winner submissions when both gates are enabled', async () => {
-      resourceApiService.getMemberResourcesRoles.mockResolvedValue([
-        { roleName: 'Submitter' },
-      ]);
-      challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
-        status: ChallengeStatus.COMPLETED,
-        track: 'Design',
-        metadata: {
-          submissionsViewable: 'true',
           allowAllRegistrantsToDownloadWinningSubmissions: 'true',
         },
         winners: [{ userId: 'owner-user', placement: 1 }],
@@ -1362,7 +1302,7 @@ describe('SubmissionService', () => {
       expect(s3Send).toHaveBeenCalledTimes(2);
     });
 
-    it('uses passing-submitter eligibility for viewable Design challenges when the new flag is disabled', async () => {
+    it('uses passing-submitter eligibility for Design challenges when legacy visibility is disabled', async () => {
       resourceApiService.getMemberResourcesRoles.mockResolvedValue([
         { roleName: 'Submitter' },
       ]);
@@ -1370,7 +1310,7 @@ describe('SubmissionService', () => {
         status: ChallengeStatus.COMPLETED,
         track: 'Design',
         metadata: {
-          submissionsViewable: 'true',
+          submissionsViewable: 'false',
           allowAllRegistrantsToDownloadWinningSubmissions: 'false',
         },
         winners: [{ userId: 'owner-user', placement: 1 }],
@@ -1391,7 +1331,7 @@ describe('SubmissionService', () => {
       expect(s3Send).toHaveBeenCalledTimes(2);
     });
 
-    it('denies a non-passing submitter for a viewable Design challenge when the new flag is disabled', async () => {
+    it('denies a non-passing Design submitter when the new flag is disabled regardless of legacy visibility', async () => {
       resourceApiService.getMemberResourcesRoles.mockResolvedValue([
         { roleName: 'Submitter' },
       ]);
@@ -1399,7 +1339,7 @@ describe('SubmissionService', () => {
         status: ChallengeStatus.COMPLETED,
         track: 'Design',
         metadata: {
-          submissionsViewable: 'true',
+          submissionsViewable: 'false',
           allowAllRegistrantsToDownloadWinningSubmissions: 'false',
         },
         winners: [{ userId: 'owner-user', placement: 1 }],

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -81,7 +81,6 @@ type SubmissionDownloadCandidate = {
 
 const ALLOW_ALL_REGISTRANTS_TO_DOWNLOAD_WINNING_SUBMISSIONS_METADATA_KEY =
   'allowAllRegistrantsToDownloadWinningSubmissions';
-const SUBMISSIONS_VIEWABLE_METADATA_KEY = 'submissionsViewable';
 const NON_WINNING_SUBMISSION_STATUSES: SubmissionStatus[] = [
   SubmissionStatus.FAILED_SCREENING,
   SubmissionStatus.FAILED_REVIEW,
@@ -1287,8 +1286,7 @@ export class SubmissionService {
    * - When `allowAllRegistrantsToDownloadWinningSubmissions` is exactly
    *   `"true"`, every registered Submitter may download only an exact final
    *   winning submission after completion. Other metadata values retain legacy
-   *   passing or First2Finish eligibility. Design challenges additionally
-   *   require `submissionsViewable` to be true.
+   *   passing or First2Finish eligibility.
    *
    * The file is always fetched from the configured clean bucket, never from DMZ.
    * The S3 key is derived from the submission.url.
@@ -1504,13 +1502,12 @@ export class SubmissionService {
    * Evaluates post-challenge download access for a registered Submitter.
    *
    * This method is used only after the caller has been confirmed to hold the
-   * challenge's Submitter resource role. The challenge must be completed. For
-   * Design challenges, `submissionsViewable` is an outer gate. Once that gate
-   * passes, exact `"true"` makes the requested target decisive: it must be the
-   * exact canonical result for a recorded placement winner (or carry matching
-   * legacy placement data), and a non-winner fails closed without legacy
-   * fallback. Other metadata values retain the legacy First2Finish or
-   * passing-submission eligibility behavior.
+   * challenge's Submitter resource role. The challenge must be completed. Exact
+   * `"true"` makes the requested target decisive: it must be the exact canonical
+   * result for a recorded placement winner (or carry matching legacy placement
+   * data), and a non-winner fails closed without legacy fallback. Other metadata
+   * values retain the legacy First2Finish or passing-submission eligibility
+   * behavior.
    *
    * @param challengeId - Challenge containing the requested submission.
    * @param requesterMemberId - Registered Submitter requesting the download.
@@ -1528,13 +1525,6 @@ export class SubmissionService {
       await this.challengeApiService.getChallengeDetail(challengeId);
 
     if (challenge.status !== ChallengeStatus.COMPLETED) {
-      return false;
-    }
-
-    if (
-      this.isDesignChallenge(challenge) &&
-      !this.isSubmissionsViewableAfterChallengeEnd(challenge)
-    ) {
       return false;
     }
 
@@ -1568,45 +1558,6 @@ export class SubmissionService {
       select: { id: true },
     });
     return Boolean(passingSubmission);
-  }
-
-  /**
-   * Determines whether a challenge belongs to the Design track.
-   *
-   * The current track name is preferred, while the legacy track is checked so
-   * migrated Design challenges receive the same visibility gate.
-   *
-   * @param challenge - Challenge metadata returned by the challenge service.
-   * @returns True when either current or legacy track is named Design.
-   * @throws Never.
-   */
-  private isDesignChallenge(challenge: ChallengeData): boolean {
-    return [challenge.track, challenge.legacy?.track].some(
-      (track) =>
-        String(track ?? '')
-          .trim()
-          .toLowerCase() === 'design',
-    );
-  }
-
-  /**
-   * Reads the existing Design submission-visibility setting.
-   *
-   * Existing challenge data and clients historically treat the string value
-   * case-insensitively, so this gate preserves that behavior.
-   *
-   * @param challenge - Challenge containing the metadata record.
-   * @returns True only when `submissionsViewable` represents true.
-   * @throws Never.
-   */
-  private isSubmissionsViewableAfterChallengeEnd(
-    challenge: ChallengeData,
-  ): boolean {
-    return (
-      String(challenge.metadata?.[SUBMISSIONS_VIEWABLE_METADATA_KEY] ?? '')
-        .trim()
-        .toLowerCase() === 'true'
-    );
   }
 
   /**


### PR DESCRIPTION
## What was broken

Design challenge winner downloads were blocked by the legacy submissionsViewable value even when the dedicated all-registrants flag was enabled or the requester qualified as a passing submitter.

## Root cause

Post-completion download authorization applied a Design-specific visibility gate before evaluating the dedicated winning-download policy.

## What was changed

Removed only the obsolete Design visibility gate and its unused helpers. Registered Submitter role, completed status, exact-winner matching, privileged access, First2Finish behavior, and passing-submitter fallback remain unchanged. Updated endpoint documentation to match.

## Any added/updated tests

Updated Design authorization cases for all registrants, passing submitters, and denied non-passing submitters with legacy visibility false. The focused authorization suite passes 29 of 29 tests, and `pnpm lint` plus `pnpm build` pass. The required full suite was also run: 17 suites passed and four existing suites failed with eight unrelated appeal, AI orchestration, and unchanged listSubmission failures.
