### PR TITLE
PM-5747: require passing Design F2F submissions for winner downloads

### DIFF
--- a/src/api/submission/submission.controller.ts
+++ b/src/api/submission/submission.controller.ts
@@ -405,7 +405,7 @@ export class SubmissionController {
   @ApiOperation({
     summary: 'Download the submission',
     description:
-      'Roles: Copilot, Admin, User, Reviewer. After challenge completion, the exact metadata value allowAllRegistrantsToDownloadWinningSubmissions=true lets every registered Submitter download only an exact final winning submission and denies non-winners without legacy fallback. Other values retain legacy passing or First2Finish eligibility. Design challenges also require submissionsViewable. | Scopes: read:submission',
+      'Roles: Copilot, Admin, User, Reviewer. After challenge completion, the exact metadata value allowAllRegistrantsToDownloadWinningSubmissions=true lets every registered Submitter download only an exact final winning submission and denies non-winners without legacy fallback. Other values require passing-submission eligibility, except non-Design First2Finish challenges retain legacy submitter eligibility. Design challenges also require submissionsViewable. | Scopes: read:submission',
   })
   @ApiParam({
     name: 'submissionId',

--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -1421,6 +1421,52 @@ describe('SubmissionService', () => {
       expect(s3Send).not.toHaveBeenCalled();
     });
 
+    it('denies a failed Design First2Finish submitter when the new flag is disabled', async () => {
+      resourceApiService.getMemberResourcesRoles.mockResolvedValue([
+        { roleName: 'Submitter' },
+      ]);
+      challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+        status: ChallengeStatus.COMPLETED,
+        type: 'First2Finish',
+        track: 'Design',
+        metadata: {
+          submissionsViewable: 'true',
+        },
+        winners: [{ userId: 'owner-user', placement: 1 }],
+      });
+      prismaMock.submission.findFirst.mockImplementation(({ where }) =>
+        Promise.resolve(
+          where.reviewSummation ? null : { id: 'failed-own-submission' },
+        ),
+      );
+
+      await expect(
+        service.getSubmissionFileStream(
+          {
+            userId: 'failed-first2finish-submitter',
+            isMachine: false,
+            roles: [],
+          } as any,
+          'sub-123',
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(prismaMock.submission.findFirst).toHaveBeenCalledTimes(1);
+      expect(prismaMock.submission.findFirst).toHaveBeenCalledWith({
+        where: {
+          challengeId: 'challenge-xyz',
+          memberId: 'failed-first2finish-submitter',
+          reviewSummation: {
+            some: {
+              isPassing: true,
+            },
+          },
+        },
+        select: { id: true },
+      });
+      expect(s3Send).not.toHaveBeenCalled();
+    });
+
     it('preserves manager access when Design submissions are not viewable', async () => {
       resourceApiService.getMemberResourcesRoles.mockResolvedValue([
         { roleName: 'Manager' },

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -1286,8 +1286,9 @@ export class SubmissionService {
    *   eligible reviewers, copilots, or managers.
    * - When `allowAllRegistrantsToDownloadWinningSubmissions` is exactly
    *   `"true"`, every registered Submitter may download only an exact final
-   *   winning submission after completion. Other metadata values retain legacy
-   *   passing or First2Finish eligibility. Design challenges additionally
+   *   winning submission after completion. Other metadata values require
+   *   passing-submission eligibility, except non-Design First2Finish challenges
+   *   retain legacy submitter eligibility. Design challenges additionally
    *   require `submissionsViewable` to be true.
    *
    * The file is always fetched from the configured clean bucket, never from DMZ.
@@ -1509,8 +1510,9 @@ export class SubmissionService {
    * passes, exact `"true"` makes the requested target decisive: it must be the
    * exact canonical result for a recorded placement winner (or carry matching
    * legacy placement data), and a non-winner fails closed without legacy
-   * fallback. Other metadata values retain the legacy First2Finish or
-   * passing-submission eligibility behavior.
+   * fallback. Other metadata values require passing-submission eligibility,
+   * except non-Design First2Finish challenges retain legacy submitter
+   * eligibility.
    *
    * @param challengeId - Challenge containing the requested submission.
    * @param requesterMemberId - Registered Submitter requesting the download.
@@ -1544,7 +1546,10 @@ export class SubmissionService {
       return this.isWinningSubmission(challengeId, challenge, submission);
     }
 
-    if (this.isFirst2FinishChallenge(challenge)) {
+    if (
+      this.isFirst2FinishChallenge(challenge) &&
+      !this.isDesignChallenge(challenge)
+    ) {
       const memberSubmission = await this.prisma.submission.findFirst({
         where: {
           challengeId,


### PR DESCRIPTION
What was broken

A registered submitter whose Design First2Finish submission failed iterative review could download the winning submission when all-registrant winner downloads were disabled.

Root cause

The legacy First2Finish authorization branch treated owning any submission as sufficient and returned before the passing-submission eligibility check, including for Design challenges.

What was changed

Limited the legacy any-submission First2Finish eligibility rule to non-Design challenges. Design First2Finish submitters now require a passing submission unless all-registrant winner downloads are enabled.

Updated the submission download endpoint documentation and service JSDoc to describe the narrowed authorization rule. No UI change is needed because the authenticated download endpoint is the authorization boundary.

Any added/updated tests

Added a regression test that models a Design First2Finish member with an owned submission but no passing review summation and verifies that the winning submission download is denied before storage access.

Validation:
- `pnpm exec jest src/api/submission/submission.service.spec.ts --runInBand --testNamePattern='getSubmissionFileStream'` — passed, 32 tests
- `pnpm lint` — passed
- `pnpm build` — passed
- `pnpm test` — 274 tests passed; eight unrelated failures remain in four suites and reproduce unchanged on `origin/develop`
