### PR TITLE
PM-5749: allow downloads after adjusted passing reviews

### DIFF
--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -609,6 +609,7 @@ describe('SubmissionService', () => {
   describe('getSubmissionFileStream', () => {
     let prismaMock: {
       challengeResult: { findUnique: jest.Mock };
+      reviewSummation: { findMany: jest.Mock };
       submission: { findFirst: jest.Mock; findMany: jest.Mock };
     };
     let challengeApiServiceMock: { getChallengeDetail: jest.Mock };
@@ -618,6 +619,9 @@ describe('SubmissionService', () => {
       prismaMock = {
         challengeResult: {
           findUnique: jest.fn().mockResolvedValue(null),
+        },
+        reviewSummation: {
+          findMany: jest.fn().mockResolvedValue([]),
         },
         submission: {
           findFirst: jest.fn(),
@@ -794,6 +798,123 @@ describe('SubmissionService', () => {
         select: { id: true },
       });
       expect(s3Send).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses an adjusted passing Review score when the stored summation is stale', async () => {
+      resourceApiService.getMemberResourcesRoles.mockResolvedValue([
+        { roleName: 'Submitter' },
+      ]);
+      challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+        status: ChallengeStatus.COMPLETED,
+        track: 'Design',
+        metadata: {
+          submissionsViewable: 'true',
+        },
+        winners: [{ userId: 'owner-user', placement: 1 }],
+      });
+      prismaMock.submission.findFirst.mockResolvedValue(null);
+      prismaMock.reviewSummation.findMany.mockResolvedValue([
+        {
+          scorecardId: 'review-scorecard',
+          updatedAt: new Date('2026-07-24T07:18:53.107Z'),
+          submission: {
+            review: [
+              {
+                scorecardId: 'review-scorecard',
+                initialScore: 68.13,
+                finalScore: 76.13,
+                updatedAt: new Date('2026-07-24T07:20:20.000Z'),
+                scorecard: {
+                  minScore: 75,
+                  minimumPassingScore: 75,
+                },
+              },
+            ],
+          },
+        },
+      ]);
+
+      const result = await service.getSubmissionFileStream(
+        {
+          userId: 'passing-submitter',
+          isMachine: false,
+          roles: [],
+        } as any,
+        'sub-123',
+      );
+
+      expect(result.fileName).toBe('submission-sub-123.zip');
+      expect(prismaMock.reviewSummation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            isFinal: true,
+            isPassing: false,
+            submission: {
+              challengeId: 'challenge-xyz',
+              memberId: 'passing-submitter',
+            },
+          }),
+        }),
+      );
+      expect(s3Send).toHaveBeenCalledTimes(2);
+    });
+
+    it('denies a stale summation when the adjusted Review average is below the passing score', async () => {
+      resourceApiService.getMemberResourcesRoles.mockResolvedValue([
+        { roleName: 'Submitter' },
+      ]);
+      challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+        status: ChallengeStatus.COMPLETED,
+        track: 'Design',
+        metadata: {
+          submissionsViewable: 'true',
+        },
+        winners: [{ userId: 'owner-user', placement: 1 }],
+      });
+      prismaMock.submission.findFirst.mockResolvedValue(null);
+      prismaMock.reviewSummation.findMany.mockResolvedValue([
+        {
+          scorecardId: 'review-scorecard',
+          updatedAt: new Date('2026-07-24T07:18:53.107Z'),
+          submission: {
+            review: [
+              {
+                scorecardId: 'review-scorecard',
+                initialScore: 80,
+                finalScore: 80,
+                updatedAt: new Date('2026-07-24T07:20:20.000Z'),
+                scorecard: {
+                  minScore: 75,
+                  minimumPassingScore: 75,
+                },
+              },
+              {
+                scorecardId: 'review-scorecard',
+                initialScore: 60,
+                finalScore: 60,
+                updatedAt: new Date('2026-07-24T07:20:21.000Z'),
+                scorecard: {
+                  minScore: 75,
+                  minimumPassingScore: 75,
+                },
+              },
+            ],
+          },
+        },
+      ]);
+
+      await expect(
+        service.getSubmissionFileStream(
+          {
+            userId: 'non-passing-submitter',
+            isMachine: false,
+            roles: [],
+          } as any,
+          'sub-123',
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(s3Send).not.toHaveBeenCalled();
     });
 
     it('matches the exact canonical winner across duplicate owner placements despite completed-without-win status', async () => {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -1561,7 +1561,125 @@ export class SubmissionService {
       },
       select: { id: true },
     });
-    return Boolean(passingSubmission);
+    if (passingSubmission) {
+      return true;
+    }
+
+    return this.hasPassingStaleReviewSummation(
+      challengeId,
+      requesterMemberId,
+    );
+  }
+
+  /**
+   * Rechecks a demonstrably stale, non-passing final Review summation.
+   *
+   * Completed, committed Review and Iterative Review scores for the same
+   * submission and scorecard are averaged only when a review was updated after
+   * its final summation. The current average is compared with the scorecard's
+   * minimum passing score, with its legacy minimum score as fallback.
+   *
+   * @param challengeId - Challenge containing the requester's submissions.
+   * @param memberId - Registered Submitter whose passing score is required.
+   * @returns True when a stale summation now has a passing Review average.
+   * @throws Error when summations or current review scores cannot be read.
+   */
+  private async hasPassingStaleReviewSummation(
+    challengeId: string,
+    memberId: string,
+  ): Promise<boolean> {
+    const reviewScorecardTypes = [
+      ScorecardType.REVIEW,
+      ScorecardType.ITERATIVE_REVIEW,
+    ];
+    const reviewScorecardWhere = {
+      type: {
+        in: reviewScorecardTypes,
+      },
+    };
+    const completedReviewWhere = {
+      committed: true,
+      status: ReviewStatus.COMPLETED,
+      scorecard: reviewScorecardWhere,
+    };
+    const summations = await this.prisma.reviewSummation.findMany({
+      where: {
+        isFinal: true,
+        isPassing: false,
+        scorecard: reviewScorecardWhere,
+        submission: {
+          challengeId,
+          memberId,
+        },
+      },
+      select: {
+        scorecardId: true,
+        updatedAt: true,
+        submission: {
+          select: {
+            review: {
+              where: completedReviewWhere,
+              select: {
+                scorecardId: true,
+                initialScore: true,
+                finalScore: true,
+                updatedAt: true,
+                scorecard: {
+                  select: {
+                    minScore: true,
+                    minimumPassingScore: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return summations.some((summation) => {
+      if (!summation.scorecardId) {
+        return false;
+      }
+
+      const matchingReviews = summation.submission.review.filter(
+        (review) => review.scorecardId === summation.scorecardId,
+      );
+      if (
+        !matchingReviews.length ||
+        !matchingReviews.some(
+          (review) => review.updatedAt > summation.updatedAt,
+        )
+      ) {
+        return false;
+      }
+
+      const scores = matchingReviews
+        .map((review) => review.finalScore ?? review.initialScore)
+        .filter(
+          (score): score is number =>
+            typeof score === 'number' && Number.isFinite(score),
+        );
+      if (!scores.length) {
+        return false;
+      }
+
+      const scorecard = matchingReviews[0].scorecard;
+      const minimumPassingScore = Number.isFinite(
+        scorecard.minimumPassingScore,
+      )
+        ? scorecard.minimumPassingScore
+        : Number.isFinite(scorecard.minScore)
+          ? scorecard.minScore
+          : null;
+      if (minimumPassingScore === null) {
+        return false;
+      }
+
+      const total = scores.reduce((sum, score) => sum + score, 0);
+      const aggregateScore = Math.round((total / scores.length) * 100) / 100;
+      return aggregateScore >= minimumPassingScore;
+    });
   }
 
   /**


### PR DESCRIPTION
What was broken

A Design submitter whose Review score was adjusted above the passing threshold during Approval could still receive a 403 when downloading a winning submission.

Root cause

Download authorization trusted a final review summation captured before the score adjustment. In the reported challenge, the stored summation remained at 68.13/non-passing while the newer completed Review score was 76.13 against a passing threshold of 75.

What was changed

Preserved the existing passing-summation path and added a fail-closed read-time fallback. It recalculates only final non-passing summations whose completed, committed Review data is newer, matches the same submission and scorecard, and has a passing averaged score.

Any added/updated tests

Added regression coverage for the reported stale-summation/passing-score scenario and for a multi-review average that remains below the passing threshold.

The focused download authorization suite passes 32 tests. Lint and build pass. The required full Jest run completed with 294 passing tests and 8 unrelated baseline failures across four existing suites; no PM-5749 regression failed.
