### PR TITLE
PM-5758: enforce design submission limits atomically

### DIFF
--- a/src/api/review/review.service.spec.ts
+++ b/src/api/review/review.service.spec.ts
@@ -9,6 +9,7 @@ import { JwtUser } from 'src/shared/modules/global/jwt.service';
 import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
 import { UserRole } from 'src/shared/enums/userRole.enum';
 import { CommonConfig } from 'src/shared/config/common.config';
+import { ScorecardType, SubmissionType } from '@prisma/client';
 
 describe('ReviewService.createReview authorization checks', () => {
   const prismaMock = {
@@ -163,7 +164,8 @@ describe('ReviewService.createReview authorization checks', () => {
         id: 'submission-1',
         challengeId: 'challenge-1',
         memberId: null,
-        isLatest: true,
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(1),
       },
     ]);
     prismaMock.reviewType.findUnique.mockResolvedValue({
@@ -212,7 +214,8 @@ describe('ReviewService.createReview authorization checks', () => {
         id: 'submission-older',
         challengeId: 'challenge-1',
         memberId: 'member-1',
-        isLatest: false,
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(2),
       },
     ]);
 
@@ -231,7 +234,8 @@ describe('ReviewService.createReview authorization checks', () => {
         id: submissionId,
         challengeId: 'challenge-1',
         memberId: 'member-1',
-        isLatest: true,
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(1),
       },
     ]);
 
@@ -255,6 +259,216 @@ describe('ReviewService.createReview authorization checks', () => {
     } finally {
       computeSpy.mockRestore();
     }
+  });
+
+  it('allows a standard Review after the submission passes Screening', async () => {
+    const submissionId = 'submission-screening-passed';
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          id: submissionId,
+          challengeId: 'challenge-1',
+          memberId: 'member-1',
+          type: SubmissionType.CONTEST_SUBMISSION,
+          submissionRank: BigInt(1),
+        },
+      ])
+      .mockResolvedValueOnce([{ passed: true }]);
+    challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+      ...baseChallengeDetail,
+      phases: [
+        { id: 'phase-screening', name: 'Screening', isOpen: false },
+        ...baseChallengeDetail.phases,
+      ],
+    });
+
+    const request = buildReviewRequest({ submissionId });
+    const reviewCreateResult = buildReviewModel(request);
+    prismaMock.review.create.mockResolvedValue(reviewCreateResult);
+    prismaMock.review.update.mockResolvedValue(reviewCreateResult);
+    const computeSpy = jest
+      .spyOn(service as any, 'computeScoresFromItems')
+      .mockResolvedValue({ initialScore: null, finalScore: null });
+
+    try {
+      await expect(
+        service.createReview(baseAuthUser, request),
+      ).resolves.toMatchObject({ submissionId });
+    } finally {
+      computeSpy.mockRestore();
+    }
+
+    const screeningQuery = prismaMock.$queryRaw.mock.calls[1][0] as {
+      strings: string[];
+      values: unknown[];
+    };
+    expect(screeningQuery.strings.join(' ')).toContain('sc."type" =');
+    expect(screeningQuery.values).toContain(ScorecardType.SCREENING);
+  });
+
+  it.each([
+    ['failed', [{ passed: false }]],
+    ['missing', []],
+  ])(
+    'rejects a standard Review when the Screening result is %s',
+    async (_description, screeningRows) => {
+      const submissionId = 'submission-screening-not-passed';
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: submissionId,
+            challengeId: 'challenge-1',
+            memberId: 'member-1',
+            type: SubmissionType.CONTEST_SUBMISSION,
+            submissionRank: BigInt(1),
+          },
+        ])
+        .mockResolvedValueOnce(screeningRows);
+      challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+        ...baseChallengeDetail,
+        phases: [
+          { id: 'phase-screening', name: 'Screening', isOpen: false },
+          ...baseChallengeDetail.phases,
+        ],
+      });
+
+      await expect(
+        service.createReview(
+          baseAuthUser,
+          buildReviewRequest({ submissionId }),
+        ),
+      ).rejects.toMatchObject({
+        response: expect.objectContaining({
+          code: 'SUBMISSION_SCREENING_NOT_PASSED',
+          details: expect.objectContaining({
+            submissionId,
+            requiredScorecardType: ScorecardType.SCREENING,
+          }),
+        }),
+      });
+      expect(prismaMock.review.create).not.toHaveBeenCalled();
+    },
+  );
+
+  it('allows the second-newest submission for a Design challenge limited to two', async () => {
+    const submissionId = 'submission-second-newest';
+    prismaMock.$queryRaw.mockResolvedValue([
+      {
+        id: submissionId,
+        challengeId: 'challenge-1',
+        memberId: 'member-1',
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(2),
+      },
+    ]);
+    challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+      ...baseChallengeDetail,
+      track: 'Design',
+      metadata: {
+        submissionLimit: JSON.stringify({
+          maximum: '2',
+          limit: 'yes',
+          unlimited: 'no',
+        }),
+      },
+    });
+
+    const request = buildReviewRequest({ submissionId });
+    const reviewCreateResult = buildReviewModel(request);
+    prismaMock.review.create.mockResolvedValue(reviewCreateResult);
+    prismaMock.review.update.mockResolvedValue(reviewCreateResult);
+    const computeSpy = jest
+      .spyOn(service as any, 'computeScoresFromItems')
+      .mockResolvedValue({ initialScore: null, finalScore: null });
+
+    try {
+      await expect(
+        service.createReview(baseAuthUser, request),
+      ).resolves.toMatchObject({ submissionId });
+    } finally {
+      computeSpy.mockRestore();
+    }
+
+    const rankSql = prismaMock.$queryRaw.mock.calls[0][0] as {
+      strings: string[];
+    };
+    const rankSqlText = rankSql.strings.join(' ');
+    expect(rankSqlText).toContain(
+      'PARTITION BY COALESCE(s."memberId", s."id"), s."type"',
+    );
+    expect(rankSqlText).toContain('s."type" IS NOT DISTINCT FROM');
+    expect(rankSqlText).toContain(
+      's."status" IS NULL OR s."status" <> \'DELETED\'',
+    );
+  });
+
+  it('rejects a Design submission outside a finite latest-X limit', async () => {
+    prismaMock.$queryRaw.mockResolvedValue([
+      {
+        id: 'submission-third-newest',
+        challengeId: 'challenge-1',
+        memberId: 'member-1',
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(3),
+      },
+    ]);
+    challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+      ...baseChallengeDetail,
+      track: 'Design',
+      metadata: {
+        submissionLimit: JSON.stringify({
+          count: '2',
+          limit: 'true',
+          unlimited: 'false',
+        }),
+      },
+    });
+
+    await expect(
+      service.createReview(
+        baseAuthUser,
+        buildReviewRequest({ submissionId: 'submission-third-newest' }),
+      ),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({
+        code: 'SUBMISSION_NOT_LATEST',
+        details: expect.objectContaining({
+          submissionRank: 3,
+          submissionLimit: 2,
+        }),
+      }),
+    });
+  });
+
+  it('keeps Development challenges latest-only even with unlimited metadata', async () => {
+    prismaMock.$queryRaw.mockResolvedValue([
+      {
+        id: 'development-older',
+        challengeId: 'challenge-1',
+        memberId: 'member-1',
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(2),
+      },
+    ]);
+    challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
+      ...baseChallengeDetail,
+      metadata: {
+        submissionLimit: JSON.stringify({
+          count: '',
+          limit: 'false',
+          unlimited: 'true',
+        }),
+      },
+    });
+
+    await expect(
+      service.createReview(
+        baseAuthUser,
+        buildReviewRequest({ submissionId: 'development-older' }),
+      ),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({ code: 'SUBMISSION_NOT_LATEST' }),
+    });
   });
 
   it('allows Post-Mortem review creation without submission when phase is open', async () => {
@@ -333,12 +547,14 @@ describe('ReviewService.createReview authorization checks', () => {
         id: submissionId,
         challengeId: 'challenge-1',
         memberId: 'member-1',
-        isLatest: false,
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(2),
       },
     ]);
 
     challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
       ...baseChallengeDetail,
+      track: 'Design',
       metadata: {
         submissionLimit: { unlimited: 'TRUE' },
       },
@@ -373,12 +589,14 @@ describe('ReviewService.createReview authorization checks', () => {
         id: submissionId,
         challengeId: 'challenge-1',
         memberId: 'member-1',
-        isLatest: false,
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(2),
       },
     ]);
 
     challengeApiServiceMock.getChallengeDetail.mockResolvedValue({
       ...baseChallengeDetail,
+      track: 'Design',
       metadata: {
         submissionLimit: { unlimited: true },
       },
@@ -413,7 +631,8 @@ describe('ReviewService.createReview authorization checks', () => {
         id: submissionId,
         challengeId: 'challenge-1',
         memberId: null,
-        isLatest: false,
+        type: SubmissionType.CONTEST_SUBMISSION,
+        submissionRank: BigInt(2),
       },
     ]);
 

--- a/src/api/review/review.service.ts
+++ b/src/api/review/review.service.ts
@@ -38,6 +38,10 @@ import { CommonConfig } from 'src/shared/config/common.config';
 import { ChallengeStatus } from 'src/shared/enums/challengeStatus.enum';
 import { UserRole } from 'src/shared/enums/userRole.enum';
 import { ResourceInfo } from 'src/shared/models/ResourceInfo.model';
+import {
+  isSubmissionRankEligible,
+  resolveReviewSubmissionRankLimit,
+} from 'src/shared/utils/submission-limit.util';
 
 const REVIEW_ITEM_COMMENTS_INCLUDE = {
   reviewItemComments: {
@@ -1126,11 +1130,12 @@ export class ReviewService {
         id: string;
         challengeId: string | null;
         memberId: string | null;
-        isLatest: boolean | null;
+        type: SubmissionType;
+        submissionRank: bigint | number | null;
       } | null = null;
       let challengeId: string | undefined;
       let submissionMemberId: string | null = null;
-      let submissionIsLatest = false;
+      let submissionRank: number | null = null;
 
       if (normalizedSubmissionId) {
         const submissions = await this.prisma.$queryRaw<
@@ -1138,11 +1143,12 @@ export class ReviewService {
             id: string;
             challengeId: string | null;
             memberId: string | null;
-            isLatest: boolean | null;
+            type: SubmissionType;
+            submissionRank: bigint | number | null;
           }>
         >(Prisma.sql`
           WITH target AS (
-            SELECT s."challengeId"
+            SELECT s."challengeId", s."type"
             FROM "submission" s
             WHERE s."id" = ${normalizedSubmissionId}
           )
@@ -1150,27 +1156,30 @@ export class ReviewService {
             ranked."id",
             ranked."challengeId",
             ranked."memberId",
-            ranked."isLatest"
+            ranked."type",
+            ranked."submissionRank"
           FROM (
             SELECT
               s."id",
               s."challengeId",
               s."memberId",
-              CASE
-                WHEN ROW_NUMBER() OVER (
-                  PARTITION BY COALESCE(s."memberId", s."id")
-                  ORDER BY
-                    s."submittedDate" DESC NULLS LAST,
-                    s."createdAt" DESC NULLS LAST,
-                    s."updatedAt" DESC NULLS LAST,
-                    s."id" DESC
-                ) = 1 THEN TRUE
-                ELSE FALSE
-              END AS "isLatest"
+              s."type",
+              ROW_NUMBER() OVER (
+                PARTITION BY COALESCE(s."memberId", s."id"), s."type"
+                ORDER BY
+                  s."submittedDate" DESC NULLS LAST,
+                  s."createdAt" DESC NULLS LAST,
+                  s."updatedAt" DESC NULLS LAST,
+                  s."id" DESC
+              ) AS "submissionRank"
             FROM "submission" s
             WHERE s."challengeId" IS NOT DISTINCT FROM (
               SELECT target."challengeId" FROM target
             )
+              AND s."type" IS NOT DISTINCT FROM (
+                SELECT target."type" FROM target
+              )
+              AND (s."status" IS NULL OR s."status" <> 'DELETED')
           ) ranked
           WHERE ranked."id" = ${normalizedSubmissionId}
         `);
@@ -1196,7 +1205,10 @@ export class ReviewService {
         submissionMemberId = submission.memberId
           ? String(submission.memberId)
           : null;
-        submissionIsLatest = Boolean(submission.isLatest);
+        const numericSubmissionRank = Number(submission.submissionRank);
+        submissionRank = Number.isInteger(numericSubmissionRank)
+          ? numericSubmissionRank
+          : null;
       }
 
       const reviewType = await this.prisma.reviewType.findUnique({
@@ -1452,23 +1464,49 @@ export class ReviewService {
 
       if (
         submission &&
-        this.shouldEnforceLatestSubmissionForReview(
+        submissionMemberId &&
+        !this.isSubmissionRankEligibleForReview(
           reviewType.name,
           challenge,
-        ) &&
-        submissionMemberId &&
-        !submissionIsLatest
+          submissionRank,
+        )
       ) {
+        const submissionLimit = resolveReviewSubmissionRankLimit(challenge);
         throw new BadRequestException({
           message:
-            'Reviews can only be created for the most recent submission per member when the challenge does not allow unlimited submissions.',
+            submissionLimit === 1
+              ? 'Reviews can only be created for the most recent submission per member for this challenge.'
+              : `Reviews can only be created for the latest ${submissionLimit} submissions per member for this challenge.`,
           code: 'SUBMISSION_NOT_LATEST',
           details: {
             submissionId: body.submissionId,
             challengeId,
             memberId: submissionMemberId,
             reviewType: reviewType.name,
-            isLatest: submissionIsLatest,
+            submissionRank,
+            submissionLimit,
+          },
+        });
+      }
+
+      const hasScreeningPhase = (challenge?.phases ?? []).some(
+        (phase) => this.normalizePhaseName(phase?.name) === 'screening',
+      );
+      if (
+        submission &&
+        this.normalizePhaseName(reviewTypeName) === 'review' &&
+        hasScreeningPhase &&
+        !(await this.hasPassedScreeningReview(submission.id))
+      ) {
+        throw new BadRequestException({
+          message:
+            'A submission must pass Screening before a Review can be created.',
+          code: 'SUBMISSION_SCREENING_NOT_PASSED',
+          details: {
+            submissionId: submission.id,
+            challengeId,
+            reviewType: reviewTypeName,
+            requiredScorecardType: ScorecardType.SCREENING,
           },
         });
       }
@@ -4691,28 +4729,67 @@ export class ReviewService {
       : null;
   }
 
-  private shouldEnforceLatestSubmissionForReview(
+  /**
+   * Checks a submission's newest-first member rank before review creation.
+   *
+   * @param reviewTypeName - Review type being created.
+   * @param challenge - Challenge track and submission-limit metadata.
+   * @param submissionRank - One-based rank within the member and submission type.
+   * @returns True for non-screening review types or an eligible ranked submission.
+   * @throws Never.
+   */
+  private isSubmissionRankEligibleForReview(
     reviewTypeName: string | null | undefined,
     challenge: ChallengeData | null | undefined,
+    submissionRank: number | null,
   ): boolean {
     if (!this.isScreeningOrReviewType(reviewTypeName)) {
-      return false;
-    }
-
-    if (!challenge) {
       return true;
     }
 
-    const submissionLimit = (
-      challenge.metadata as Record<string, unknown> | undefined
-    )?.['submissionLimit'];
+    return isSubmissionRankEligible(
+      submissionRank,
+      resolveReviewSubmissionRankLimit(challenge),
+    );
+  }
 
-    const unlimited = this.extractSubmissionLimitUnlimited(submissionLimit);
-    if (unlimited === true) {
-      return false;
-    }
+  /**
+   * Checks whether a completed Screening review meets its scorecard threshold.
+   *
+   * The review and scorecard join avoids depending on member-review challenge
+   * configuration because screening can be managed by Autopilot. Legacy passed
+   * or approved review statuses remain accepted.
+   *
+   * @param submissionId - Submission advancing to the standard Review phase.
+   * @returns True when the submission has a passing Screening result.
+   * @throws Error when the review database query fails.
+   */
+  private async hasPassedScreeningReview(
+    submissionId: string,
+  ): Promise<boolean> {
+    const rows = await this.prisma.$queryRaw<Array<{ passed: boolean }>>(
+      Prisma.sql`
+        SELECT EXISTS (
+          SELECT 1
+          FROM "review" r
+          INNER JOIN "scorecard" sc ON sc."id" = r."scorecardId"
+          WHERE r."submissionId" = ${submissionId}
+            AND sc."type" = ${ScorecardType.SCREENING}
+            AND (
+              (
+                UPPER((r."status")::text) = 'COMPLETED'
+                AND GREATEST(
+                  COALESCE(r."finalScore", 0),
+                  COALESCE(r."initialScore", 0)
+                ) >= COALESCE(sc."minimumPassingScore", sc."minScore", 50)
+              )
+              OR UPPER((r."status")::text) IN ('PASSED', 'APPROVED')
+            )
+        ) AS "passed"
+      `,
+    );
 
-    return this.challengeHasSubmissionLimit(challenge);
+    return rows[0]?.passed === true;
   }
 
   private isScreeningOrReviewType(
@@ -4739,200 +4816,6 @@ export class ReviewService {
     }
 
     return false;
-  }
-
-  private challengeHasSubmissionLimit(
-    challenge: ChallengeData | null | undefined,
-  ): boolean {
-    if (!challenge?.metadata) {
-      return true;
-    }
-
-    const rawValue = challenge.metadata['submissionLimit'];
-    if (rawValue == null) {
-      return true;
-    }
-
-    let parsed: unknown = rawValue;
-
-    if (typeof rawValue === 'string') {
-      const trimmed = rawValue.trim();
-      if (!trimmed) {
-        return true;
-      }
-
-      try {
-        parsed = JSON.parse(trimmed);
-      } catch {
-        const numeric = Number(trimmed);
-        if (Number.isFinite(numeric) && numeric > 0) {
-          return true;
-        }
-        const normalized = trimmed.toLowerCase();
-        if (['unlimited', 'false', '0', 'no', 'none'].includes(normalized)) {
-          return false;
-        }
-        return true;
-      }
-    }
-
-    if (typeof parsed === 'number') {
-      return Number.isFinite(parsed) && parsed > 0;
-    }
-
-    if (typeof parsed === 'string') {
-      const numeric = Number(parsed);
-      if (Number.isFinite(numeric) && numeric > 0) {
-        return true;
-      }
-      const normalized = parsed.trim().toLowerCase();
-      if (['unlimited', 'false', '0', 'no', 'none'].includes(normalized)) {
-        return false;
-      }
-      return true;
-    }
-
-    if (parsed && typeof parsed === 'object') {
-      const unlimited = this.parseBooleanFlag((parsed as any).unlimited);
-      if (unlimited === true) {
-        return false;
-      }
-
-      const candidates = [
-        (parsed as any).count,
-        (parsed as any).max,
-        (parsed as any).maximum,
-        (parsed as any).limitCount,
-        (parsed as any).value,
-      ];
-
-      for (const candidate of candidates) {
-        if (candidate === undefined || candidate === null) {
-          continue;
-        }
-        const numeric = Number(candidate);
-        if (Number.isFinite(numeric) && numeric > 0) {
-          return true;
-        }
-      }
-
-      const limitFlag = this.parseBooleanFlag((parsed as any).limit);
-      if (limitFlag === true) {
-        return true;
-      }
-      if (limitFlag === false) {
-        return false;
-      }
-      return true;
-    }
-
-    return true;
-  }
-
-  private extractSubmissionLimitUnlimited(value: unknown): boolean | null {
-    if (value == null) {
-      return null;
-    }
-
-    if (typeof value === 'string') {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return null;
-      }
-
-      try {
-        const parsed = JSON.parse(trimmed);
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-          return this.coerceLooseBoolean(
-            (parsed as Record<string, unknown>).unlimited,
-          );
-        }
-        return this.coerceLooseBoolean(parsed);
-      } catch {
-        return this.coerceLooseBoolean(trimmed);
-      }
-    }
-
-    if (typeof value === 'object' && !Array.isArray(value)) {
-      return this.coerceLooseBoolean(
-        (value as Record<string, unknown>).unlimited,
-      );
-    }
-
-    return this.coerceLooseBoolean(value);
-  }
-
-  private coerceLooseBoolean(value: unknown): boolean | null {
-    if (value == null) {
-      return null;
-    }
-
-    if (value === true || value === false) {
-      return value;
-    }
-
-    if (value instanceof Boolean) {
-      return value.valueOf();
-    }
-
-    if (value instanceof Number) {
-      return this.coerceLooseBoolean(value.valueOf());
-    }
-
-    let candidate: string;
-
-    if (typeof value === 'string') {
-      candidate = value;
-    } else if (value instanceof String) {
-      candidate = value.valueOf();
-    } else if (typeof value === 'number') {
-      if (!Number.isFinite(value)) {
-        return null;
-      }
-      candidate = value.toString();
-    } else if (typeof value === 'bigint') {
-      candidate = value.toString();
-    } else {
-      return null;
-    }
-
-    const normalized = candidate.trim().toLowerCase();
-    if (!normalized) {
-      return null;
-    }
-    if (normalized === 'true') {
-      return true;
-    }
-    if (normalized === 'false') {
-      return false;
-    }
-    return null;
-  }
-
-  private parseBooleanFlag(value: unknown): boolean | null {
-    if (typeof value === 'boolean') {
-      return value;
-    }
-    if (typeof value === 'string') {
-      const normalized = value.trim().toLowerCase();
-      if (['true', 'yes', '1'].includes(normalized)) {
-        return true;
-      }
-      if (['false', 'no', '0'].includes(normalized)) {
-        return false;
-      }
-      return null;
-    }
-    if (typeof value === 'number') {
-      if (value === 1) {
-        return true;
-      }
-      if (value === 0) {
-        return false;
-      }
-      return null;
-    }
-    return null;
   }
 
   async deleteReview(authUser: JwtUser | undefined, reviewId: string) {

--- a/src/api/submission/submission.service.spec.ts
+++ b/src/api/submission/submission.service.spec.ts
@@ -394,9 +394,9 @@ describe('SubmissionService', () => {
           virusScan: true,
         }),
       });
-      expect(
-        prisma.submission.create.mock.calls[0][0].data,
-      ).not.toHaveProperty('confirmationEmail');
+      expect(prisma.submission.create.mock.calls[0][0].data).not.toHaveProperty(
+        'confirmationEmail',
+      );
     });
 
     it('rejects validation upload requests without file contents', async () => {
@@ -4035,6 +4035,300 @@ describe('SubmissionService', () => {
     });
   });
 
+  describe('createSubmission finite Design limits', () => {
+    let transactionClient: {
+      $executeRaw: jest.Mock;
+      submission: {
+        count: jest.Mock;
+        create: jest.Mock;
+      };
+    };
+    let prismaMock: {
+      $transaction: jest.Mock;
+      submission: {
+        create: jest.Mock;
+      };
+    };
+    let createService: SubmissionService;
+
+    const limitedDesignChallenge = {
+      id: 'challenge-limited-design',
+      legacy: {},
+      metadata: {
+        submissionLimit: JSON.stringify({
+          count: '2',
+          limit: 'true',
+          unlimited: 'false',
+        }),
+      },
+      status: ChallengeStatus.ACTIVE,
+      track: 'Design',
+      type: 'Challenge',
+    };
+    const submissionBody = {
+      challengeId: 'challenge-limited-design',
+      memberId: '1001',
+      type: SubmissionType.CONTEST_SUBMISSION,
+      url: 'https://example.com/submission.zip',
+    };
+    const submissionData = {
+      ...submissionBody,
+      isFileSubmission: true,
+      status: SubmissionStatus.ACTIVE,
+      virusScan: false,
+    };
+
+    beforeEach(() => {
+      transactionClient = {
+        $executeRaw: jest.fn().mockResolvedValue(0),
+        submission: {
+          count: jest.fn().mockResolvedValue(1),
+          create: jest.fn().mockResolvedValue({ id: 'created-submission' }),
+        },
+      };
+      prismaMock = {
+        $transaction: jest.fn((callback) => callback(transactionClient)),
+        submission: {
+          create: jest.fn().mockResolvedValue({ id: 'uncapped-submission' }),
+        },
+      };
+      createService = new SubmissionService(
+        prismaMock as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+    });
+
+    it('locks, counts, and creates in one transaction while below the limit', async () => {
+      await expect(
+        (createService as any).createSubmissionWithLimit(
+          limitedDesignChallenge,
+          submissionBody,
+          submissionData,
+        ),
+      ).resolves.toEqual({ id: 'created-submission' });
+
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      expect(transactionClient.$executeRaw).toHaveBeenCalledTimes(1);
+      expect(transactionClient.submission.count).toHaveBeenCalledWith({
+        where: {
+          challengeId: submissionBody.challengeId,
+          memberId: submissionBody.memberId,
+          type: SubmissionType.CONTEST_SUBMISSION,
+          status: { not: SubmissionStatus.DELETED },
+        },
+      });
+      expect(transactionClient.submission.create).toHaveBeenCalledWith({
+        data: submissionData,
+      });
+      expect(prismaMock.submission.create).not.toHaveBeenCalled();
+      expect(
+        transactionClient.$executeRaw.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        transactionClient.submission.count.mock.invocationCallOrder[0],
+      );
+      expect(
+        transactionClient.submission.count.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        transactionClient.submission.create.mock.invocationCallOrder[0],
+      );
+    });
+
+    it.each(['count', 'max', 'maximum', 'limitCount', 'value'])(
+      'atomically enforces the legacy finite %s alias',
+      async (countField) => {
+        const challenge = {
+          ...limitedDesignChallenge,
+          metadata: {
+            submissionLimit: JSON.stringify({
+              [countField]: '2',
+              limit: 'yes',
+              unlimited: 'no',
+            }),
+          },
+        };
+
+        await expect(
+          (createService as any).createSubmissionWithLimit(
+            challenge,
+            submissionBody,
+            submissionData,
+          ),
+        ).resolves.toEqual({ id: 'created-submission' });
+
+        expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+        expect(transactionClient.$executeRaw).toHaveBeenCalledTimes(1);
+        expect(transactionClient.submission.count).toHaveBeenCalledTimes(1);
+        expect(transactionClient.submission.create).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it('rejects atomically when the finite limit is already reached', async () => {
+      transactionClient.submission.count.mockResolvedValue(2);
+
+      await expect(
+        (createService as any).createSubmissionWithLimit(
+          limitedDesignChallenge,
+          submissionBody,
+          submissionData,
+        ),
+      ).rejects.toMatchObject({
+        response: expect.objectContaining({
+          code: 'SUBMISSION_LIMIT_REACHED',
+          details: expect.objectContaining({
+            submissionLimit: 2,
+            existingSubmissionCount: 2,
+          }),
+        }),
+      });
+
+      expect(transactionClient.submission.create).not.toHaveBeenCalled();
+    });
+
+    it('counts checkpoint and contest submissions independently', async () => {
+      const checkpointBody = {
+        ...submissionBody,
+        type: SubmissionType.CHECKPOINT_SUBMISSION,
+      };
+
+      await (createService as any).createSubmissionWithLimit(
+        limitedDesignChallenge,
+        checkpointBody,
+        { ...submissionData, type: SubmissionType.CHECKPOINT_SUBMISSION },
+      );
+
+      expect(transactionClient.submission.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          challengeId: submissionBody.challengeId,
+          memberId: submissionBody.memberId,
+          type: SubmissionType.CHECKPOINT_SUBMISSION,
+        }),
+      });
+      const advisoryLock = transactionClient.$executeRaw.mock.calls[0][0] as {
+        strings: string[];
+        values: unknown[];
+      };
+      expect(advisoryLock.strings.join(' ')).toContain('pg_advisory_xact_lock');
+      expect(advisoryLock.values).toContain(
+        `design-submission-limit:${submissionBody.challengeId}:${submissionBody.memberId}:${SubmissionType.CHECKPOINT_SUBMISSION}`,
+      );
+    });
+
+    it.each([
+      {
+        description: 'missing Design metadata',
+        challenge: { ...limitedDesignChallenge, metadata: undefined },
+      },
+      {
+        description: 'malformed Design metadata',
+        challenge: {
+          ...limitedDesignChallenge,
+          metadata: { submissionLimit: '{invalid' },
+        },
+      },
+      {
+        description: 'contradictory Design metadata',
+        challenge: {
+          ...limitedDesignChallenge,
+          metadata: {
+            submissionLimit: JSON.stringify({
+              max: '2',
+              limit: 'yes',
+              unlimited: 1,
+            }),
+          },
+        },
+      },
+      {
+        description: 'explicitly unlimited Design metadata',
+        challenge: {
+          ...limitedDesignChallenge,
+          metadata: {
+            submissionLimit: JSON.stringify({
+              max: '2',
+              limit: 'no',
+              unlimited: 'yes',
+            }),
+          },
+        },
+      },
+      {
+        description: 'non-Design challenge',
+        challenge: { ...limitedDesignChallenge, track: 'Development' },
+      },
+    ])('leaves creation uncapped for $description', async ({ challenge }) => {
+      await expect(
+        (createService as any).createSubmissionWithLimit(
+          challenge,
+          submissionBody,
+          submissionData,
+        ),
+      ).resolves.toEqual({ id: 'uncapped-submission' });
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+      expect(prismaMock.submission.create).toHaveBeenCalledWith({
+        data: submissionData,
+      });
+    });
+
+    it('serializes competing requests for the final available slot', async () => {
+      let storedSubmissionCount = 1;
+      let lockTail = Promise.resolve();
+      prismaMock.$transaction.mockImplementation(async (callback) => {
+        const previousLock = lockTail;
+        let releaseLock: () => void = () => undefined;
+        lockTail = new Promise<void>((resolve) => {
+          releaseLock = resolve;
+        });
+        await previousLock;
+
+        const serializedClient = {
+          $executeRaw: jest.fn().mockResolvedValue(0),
+          submission: {
+            count: jest.fn().mockImplementation(() => storedSubmissionCount),
+            create: jest.fn().mockImplementation(() => {
+              storedSubmissionCount += 1;
+              return { id: `submission-${storedSubmissionCount}` };
+            }),
+          },
+        };
+
+        try {
+          return await callback(serializedClient);
+        } finally {
+          releaseLock();
+        }
+      });
+
+      const results = await Promise.allSettled([
+        (createService as any).createSubmissionWithLimit(
+          limitedDesignChallenge,
+          submissionBody,
+          submissionData,
+        ),
+        (createService as any).createSubmissionWithLimit(
+          limitedDesignChallenge,
+          submissionBody,
+          submissionData,
+        ),
+      ]);
+
+      expect(
+        results.filter((result) => result.status === 'fulfilled'),
+      ).toHaveLength(1);
+      expect(
+        results.filter((result) => result.status === 'rejected'),
+      ).toHaveLength(1);
+      expect(storedSubmissionCount).toBe(2);
+    });
+  });
+
   describe('ensurePendingReviewsForSubmission', () => {
     it('creates pending reviews for open phases using challenge reviewer configuration', async () => {
       const prismaMock = {
@@ -4143,6 +4437,353 @@ describe('SubmissionService', () => {
         }),
       );
     });
+
+    it.each([
+      {
+        phaseName: 'Screening',
+        reviewTypeName: 'Screening',
+        scorecardType: ScorecardType.SCREENING,
+        submissionType: SubmissionType.CONTEST_SUBMISSION,
+      },
+      {
+        phaseName: 'Checkpoint Screening',
+        reviewTypeName: 'Checkpoint Screening',
+        scorecardType: ScorecardType.CHECKPOINT_SCREENING,
+        submissionType: SubmissionType.CHECKPOINT_SUBMISSION,
+      },
+    ])(
+      'creates $phaseName reviews for a Design submission within latest X',
+      async ({ phaseName, reviewTypeName, scorecardType, submissionType }) => {
+        const prismaMock = {
+          submission: {
+            findUnique: jest.fn().mockResolvedValue({
+              id: 'submission-ranked',
+              challengeId: 'challenge-ranked',
+              memberId: 'member-ranked',
+              type: submissionType,
+              virusScan: true,
+            }),
+          },
+          scorecard: {
+            findMany: jest
+              .fn()
+              .mockResolvedValue([
+                { id: 'scorecard-ranked', type: scorecardType },
+              ]),
+          },
+          reviewType: {
+            findMany: jest
+              .fn()
+              .mockResolvedValue([
+                { id: 'review-type-ranked', name: reviewTypeName },
+              ]),
+          },
+          review: {
+            createMany: jest.fn().mockResolvedValue({ count: 1 }),
+          },
+          aiReviewConfig: {
+            findFirst: jest.fn().mockResolvedValue(null),
+          },
+          $queryRaw: jest
+            .fn()
+            .mockResolvedValue([{ submissionRank: BigInt(2) }]),
+        };
+        const challengePrismaMock = {
+          $queryRaw: jest.fn().mockResolvedValue([
+            {
+              scorecardId: 'scorecard-ranked',
+              templatePhaseId: 'phase-template-ranked',
+              challengePhaseId: 'challenge-phase-ranked',
+              phaseName,
+            },
+          ]),
+        };
+        const challengeApiServiceMock = {
+          getChallengeDetail: jest.fn().mockResolvedValue({
+            id: 'challenge-ranked',
+            track: 'Design',
+            metadata: {
+              submissionLimit: JSON.stringify({
+                count: '2',
+                limit: 'true',
+                unlimited: 'false',
+              }),
+            },
+            phases: [
+              {
+                id: 'challenge-phase-ranked',
+                name: phaseName,
+                isOpen: true,
+              },
+            ],
+          }),
+        };
+        const resourceApiServiceMock = {
+          getResources: jest.fn().mockResolvedValue([
+            {
+              id: 'resource-ranked',
+              challengeId: 'challenge-ranked',
+              memberId: 'reviewer-ranked',
+              memberHandle: 'reviewerRanked',
+              roleId: 'role-ranked',
+              phaseId: 'challenge-phase-ranked',
+              createdBy: 'system',
+              created: new Date().toISOString(),
+            },
+          ]),
+          getResourceRoles: jest.fn().mockResolvedValue({
+            'role-ranked': { id: 'role-ranked', name: reviewTypeName },
+          }),
+        };
+        const pendingReviewService = new SubmissionService(
+          prismaMock as any,
+          {} as any,
+          challengePrismaMock as any,
+          challengeApiServiceMock as any,
+          resourceApiServiceMock as any,
+          {} as any,
+          {} as any,
+          {} as any,
+          {} as any,
+        );
+
+        await expect(
+          pendingReviewService.ensurePendingReviewsForSubmission(
+            'submission-ranked',
+            { triggerSource: 'unit-test' },
+          ),
+        ).resolves.toBe(1);
+
+        const rankQuery = prismaMock.$queryRaw.mock.calls[0][0] as {
+          strings: string[];
+          values: unknown[];
+        };
+        expect(rankQuery.strings.join(' ')).toContain(
+          'PARTITION BY COALESCE(s."memberId", s."id"), s."type"',
+        );
+        expect(rankQuery.strings.join(' ')).toContain(
+          's."status" IS NULL OR s."status" <> \'DELETED\'',
+        );
+        expect(rankQuery.values).toContain(submissionType);
+        expect(prismaMock.review.createMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.arrayContaining([
+              expect.objectContaining({ submissionId: 'submission-ranked' }),
+            ]),
+          }),
+        );
+      },
+    );
+
+    it('skips a Design screening submission outside latest X', async () => {
+      const prismaMock = {
+        submission: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'submission-too-old',
+            challengeId: 'challenge-ranked',
+            memberId: 'member-ranked',
+            type: SubmissionType.CONTEST_SUBMISSION,
+            virusScan: true,
+          }),
+        },
+        scorecard: {
+          findMany: jest
+            .fn()
+            .mockResolvedValue([
+              { id: 'scorecard-screening', type: ScorecardType.SCREENING },
+            ]),
+        },
+        reviewType: {
+          findMany: jest
+            .fn()
+            .mockResolvedValue([{ id: 'type-screening', name: 'Screening' }]),
+        },
+        review: { createMany: jest.fn() },
+        aiReviewConfig: {
+          findFirst: jest.fn().mockResolvedValue(null),
+        },
+        $queryRaw: jest.fn().mockResolvedValue([{ submissionRank: BigInt(3) }]),
+      };
+      const pendingReviewService = new SubmissionService(
+        prismaMock as any,
+        {} as any,
+        {
+          $queryRaw: jest.fn().mockResolvedValue([
+            {
+              scorecardId: 'scorecard-screening',
+              templatePhaseId: 'template-screening',
+              challengePhaseId: 'phase-screening',
+              phaseName: 'Screening',
+            },
+          ]),
+        } as any,
+        {
+          getChallengeDetail: jest.fn().mockResolvedValue({
+            id: 'challenge-ranked',
+            track: 'Design',
+            metadata: {
+              submissionLimit: JSON.stringify({
+                count: '2',
+                limit: 'true',
+                unlimited: 'false',
+              }),
+            },
+            phases: [
+              { id: 'phase-screening', name: 'Screening', isOpen: true },
+            ],
+          }),
+        } as any,
+        {
+          getResources: jest.fn().mockResolvedValue([]),
+          getResourceRoles: jest.fn().mockResolvedValue({}),
+        } as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+
+      await expect(
+        pendingReviewService.ensurePendingReviewsForSubmission(
+          'submission-too-old',
+          { triggerSource: 'unit-test' },
+        ),
+      ).resolves.toBe(0);
+      expect(prismaMock.review.createMany).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        phaseName: 'Review',
+        precedingPhaseName: 'Screening',
+        scorecardType: ScorecardType.REVIEW,
+        screeningScorecardType: ScorecardType.SCREENING,
+        submissionType: SubmissionType.CONTEST_SUBMISSION,
+      },
+      {
+        phaseName: 'Checkpoint Review',
+        precedingPhaseName: 'Checkpoint Screening',
+        scorecardType: ScorecardType.CHECKPOINT_REVIEW,
+        screeningScorecardType: ScorecardType.CHECKPOINT_SCREENING,
+        submissionType: SubmissionType.CHECKPOINT_SUBMISSION,
+      },
+    ])(
+      'requires a passing $precedingPhaseName before $phaseName creation',
+      async ({
+        phaseName,
+        precedingPhaseName,
+        scorecardType,
+        screeningScorecardType,
+        submissionType,
+      }) => {
+        const prismaMock = {
+          submission: {
+            findUnique: jest.fn().mockResolvedValue({
+              id: 'submission-screened',
+              challengeId: 'challenge-screened',
+              memberId: null,
+              type: submissionType,
+              virusScan: true,
+            }),
+          },
+          scorecard: {
+            findMany: jest
+              .fn()
+              .mockResolvedValue([
+                { id: 'scorecard-review', type: scorecardType },
+              ]),
+          },
+          reviewType: {
+            findMany: jest
+              .fn()
+              .mockResolvedValue([{ id: 'review-type', name: phaseName }]),
+          },
+          review: {
+            createMany: jest.fn().mockResolvedValue({ count: 1 }),
+          },
+          aiReviewConfig: {
+            findFirst: jest.fn().mockResolvedValue(null),
+          },
+          $queryRaw: jest.fn().mockResolvedValue([{ passed: true }]),
+        };
+        const challengePrismaMock = {
+          $queryRaw: jest.fn().mockResolvedValue([
+            {
+              scorecardId: 'scorecard-review',
+              templatePhaseId: 'template-review',
+              challengePhaseId: 'phase-review',
+              phaseName,
+            },
+          ]),
+        };
+        const challengeApiServiceMock = {
+          getChallengeDetail: jest.fn().mockResolvedValue({
+            id: 'challenge-screened',
+            track: 'Design',
+            phases: [
+              {
+                id: 'phase-screening',
+                name: precedingPhaseName,
+                isOpen: false,
+              },
+              { id: 'phase-review', name: phaseName, isOpen: true },
+            ],
+          }),
+        };
+        const resourceApiServiceMock = {
+          getResources: jest.fn().mockResolvedValue([
+            {
+              id: 'resource-review',
+              challengeId: 'challenge-screened',
+              memberId: 'reviewer',
+              memberHandle: 'reviewer',
+              roleId: 'role-review',
+              phaseId: 'phase-review',
+              createdBy: 'system',
+              created: new Date().toISOString(),
+            },
+          ]),
+          getResourceRoles: jest.fn().mockResolvedValue({
+            'role-review': { id: 'role-review', name: phaseName },
+          }),
+        };
+        const pendingReviewService = new SubmissionService(
+          prismaMock as any,
+          {} as any,
+          challengePrismaMock as any,
+          challengeApiServiceMock as any,
+          resourceApiServiceMock as any,
+          {} as any,
+          {} as any,
+          {} as any,
+          {} as any,
+        );
+
+        await expect(
+          pendingReviewService.ensurePendingReviewsForSubmission(
+            'submission-screened',
+            { triggerSource: 'unit-test' },
+          ),
+        ).resolves.toBe(1);
+
+        const passingQuery = prismaMock.$queryRaw.mock.calls[0][0] as {
+          strings: string[];
+          values: unknown[];
+        };
+        expect(passingQuery.strings.join(' ')).toContain('sc."type" =');
+        expect(passingQuery.values).toContain(screeningScorecardType);
+
+        prismaMock.review.createMany.mockClear();
+        prismaMock.$queryRaw.mockResolvedValue([{ passed: false }]);
+        await expect(
+          pendingReviewService.ensurePendingReviewsForSubmission(
+            'submission-screened',
+            { triggerSource: 'unit-test' },
+          ),
+        ).resolves.toBe(0);
+        expect(prismaMock.review.createMany).not.toHaveBeenCalled();
+      },
+    );
 
     it('skips approval pending creation because autopilot owns winner selection', async () => {
       const prismaMock = {

--- a/src/api/submission/submission.service.ts
+++ b/src/api/submission/submission.service.ts
@@ -57,6 +57,12 @@ import { EventBusService } from 'src/shared/modules/global/eventBus.service';
 import { SubmissionAccessAuditResponseDto } from 'src/dto/submission-access-audit.dto';
 import { Prisma } from '@prisma/client';
 import type { Express } from 'express';
+import {
+  isDesignTrackChallenge,
+  isSubmissionRankEligible,
+  parseSubmissionLimitCount,
+  resolveReviewSubmissionRankLimit,
+} from 'src/shared/utils/submission-limit.util';
 
 type SubmissionMinimal = {
   id: string;
@@ -91,6 +97,10 @@ const NON_WINNING_SUBMISSION_STATUSES: SubmissionStatus[] = [
   SubmissionStatus.FAILED_CHECKPOINT_REVIEW,
   SubmissionStatus.AI_FAILED_REVIEW,
 ];
+const DESIGN_LIMITED_SUBMISSION_TYPES = new Set<SubmissionType>([
+  SubmissionType.CONTEST_SUBMISSION,
+  SubmissionType.CHECKPOINT_SUBMISSION,
+]);
 
 /**
  * Parses optional boolean-like query parameters used by submission listing filters.
@@ -639,6 +649,7 @@ export class SubmissionService {
       select: {
         id: true,
         challengeId: true,
+        memberId: true,
         type: true,
         virusScan: true,
       },
@@ -690,6 +701,18 @@ export class SubmissionService {
     const challenge = await this.challengeApiService.getChallengeDetail(
       submission.challengeId,
     );
+    const submissionRankLimit = resolveReviewSubmissionRankLimit(challenge);
+    const submissionRank =
+      submission.memberId && submissionRankLimit !== null
+        ? await this.resolveSubmissionRankForReview(
+            submission.id,
+            submission.challengeId,
+            submission.type,
+          )
+        : null;
+    const isRankEligible =
+      !submission.memberId ||
+      isSubmissionRankEligible(submissionRank, submissionRankLimit);
     const autopilotManagedIterativeReview =
       this.isFirst2FinishChallenge(challenge);
 
@@ -734,6 +757,36 @@ export class SubmissionService {
         `[ensurePendingReviewsForSubmission] No member reviewer configs found for challenge ${submission.challengeId}. source=${source}`,
       );
       return 0;
+    }
+
+    const challengeHasPhase = (phaseName: string): boolean =>
+      (challenge?.phases ?? []).some(
+        (phase) => this.normalizePhaseName(phase?.name) === phaseName,
+      );
+    const openConfiguredPhase = (phaseName: string): boolean =>
+      reviewerConfigs.some(
+        (config) =>
+          this.normalizePhaseName(config.phaseName) === phaseName &&
+          openPhaseIds.has(String(config.challengePhaseId ?? '').trim()),
+      );
+
+    let hasPassedScreening = true;
+    if (openConfiguredPhase('review') && challengeHasPhase('screening')) {
+      hasPassedScreening = await this.hasPassedScreeningReview(
+        submission.id,
+        ScorecardType.SCREENING,
+      );
+    }
+
+    let hasPassedCheckpointScreening = true;
+    if (
+      openConfiguredPhase('checkpoint review') &&
+      challengeHasPhase('checkpoint screening')
+    ) {
+      hasPassedCheckpointScreening = await this.hasPassedScreeningReview(
+        submission.id,
+        ScorecardType.CHECKPOINT_SCREENING,
+      );
     }
 
     const scorecardIds = Array.from(
@@ -803,6 +856,21 @@ export class SubmissionService {
       }
 
       if (!this.isReviewPhaseSupportedForPendingCreation(normalizedPhaseName)) {
+        continue;
+      }
+
+      if (!isRankEligible) {
+        continue;
+      }
+
+      if (normalizedPhaseName === 'review' && !hasPassedScreening) {
+        continue;
+      }
+
+      if (
+        normalizedPhaseName === 'checkpoint review' &&
+        !hasPassedCheckpointScreening
+      ) {
         continue;
       }
 
@@ -2740,6 +2808,90 @@ export class SubmissionService {
     );
   }
 
+  /**
+   * Resolves a submission's newest-first rank for its member and exact type.
+   *
+   * @param submissionId - Submission whose review eligibility is being checked.
+   * @param challengeId - Challenge containing the submission.
+   * @param submissionType - Contest or checkpoint type ranked independently.
+   * @returns The one-based rank, or null when the non-deleted submission is not found.
+   * @throws Error when the review database query fails.
+   */
+  private async resolveSubmissionRankForReview(
+    submissionId: string,
+    challengeId: string,
+    submissionType: SubmissionType,
+  ): Promise<number | null> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{ submissionRank: bigint | number | null }>
+    >(Prisma.sql`
+      SELECT ranked."submissionRank"
+      FROM (
+        SELECT
+          s."id",
+          ROW_NUMBER() OVER (
+            PARTITION BY COALESCE(s."memberId", s."id"), s."type"
+            ORDER BY
+              s."submittedDate" DESC NULLS LAST,
+              s."createdAt" DESC NULLS LAST,
+              s."updatedAt" DESC NULLS LAST,
+              s."id" DESC
+          ) AS "submissionRank"
+        FROM "submission" s
+        WHERE s."challengeId" = ${challengeId}
+          AND s."type" = ${submissionType}
+          AND (s."status" IS NULL OR s."status" <> 'DELETED')
+      ) ranked
+      WHERE ranked."id" = ${submissionId}
+    `);
+
+    const numericRank = Number(rows[0]?.submissionRank);
+    return Number.isInteger(numericRank) && numericRank > 0
+      ? numericRank
+      : null;
+  }
+
+  /**
+   * Checks whether a submission passed one of the configured screening scorecards.
+   *
+   * Completed reviews use the greater of final and initial score and the same
+   * scorecard threshold fallback as autopilot. Legacy passed or approved review
+   * statuses are also accepted.
+   *
+   * @param submissionId - Submission advancing to Review or Checkpoint Review.
+   * @param screeningScorecardType - Screening scorecard type for the preceding phase.
+   * @returns True when a screening review of that type has passed.
+   * @throws Error when the review database query fails.
+   */
+  private async hasPassedScreeningReview(
+    submissionId: string,
+    screeningScorecardType: ScorecardType,
+  ): Promise<boolean> {
+    const rows = await this.prisma.$queryRaw<Array<{ passed: boolean }>>(
+      Prisma.sql`
+        SELECT EXISTS (
+          SELECT 1
+          FROM "review" r
+          INNER JOIN "scorecard" sc ON sc."id" = r."scorecardId"
+          WHERE r."submissionId" = ${submissionId}
+            AND sc."type" = ${screeningScorecardType}
+            AND (
+              (
+                UPPER((r."status")::text) = 'COMPLETED'
+                AND GREATEST(
+                  COALESCE(r."finalScore", 0),
+                  COALESCE(r."initialScore", 0)
+                ) >= COALESCE(sc."minimumPassingScore", sc."minScore", 50)
+              )
+              OR UPPER((r."status")::text) IN ('PASSED', 'APPROVED')
+            )
+        ) AS "passed"
+      `,
+    );
+
+    return rows[0]?.passed === true;
+  }
+
   private getAllowedManualUploadPhaseNames(
     submissionType: SubmissionType,
   ): string[] {
@@ -3336,6 +3488,85 @@ export class SubmissionService {
     }
   }
 
+  /**
+   * Creates a submission while atomically enforcing a finite Design limit.
+   *
+   * The transaction-scoped advisory lock serializes submissions for the same
+   * challenge, member, and exact submission type across service instances.
+   * Contest and checkpoint submissions therefore use independent limits, while
+   * unlimited Design challenges, other tracks, and other submission types keep
+   * the normal creation path.
+   *
+   * @param challenge - Challenge data used to resolve track and limit metadata.
+   * @param body - Validated submission request identifying the member and type.
+   * @param data - Prisma submission payload to persist.
+   * @returns The newly created submission.
+   * @throws BadRequestException when the member has reached the finite limit.
+   * @throws Error when locking, counting, or persistence fails.
+   */
+  private async createSubmissionWithLimit(
+    challenge: ChallengeData,
+    body: SubmissionRequestDto,
+    data: Prisma.submissionCreateArgs['data'],
+  ) {
+    const submissionType = body.type as SubmissionType;
+    const submissionLimit = isDesignTrackChallenge(challenge)
+      ? parseSubmissionLimitCount(
+          challenge.metadata?.submissionLimit as unknown,
+        )
+      : null;
+
+    if (
+      submissionLimit === null ||
+      !DESIGN_LIMITED_SUBMISSION_TYPES.has(submissionType)
+    ) {
+      return this.prisma.submission.create({ data });
+    }
+
+    const lockKey = [
+      'design-submission-limit',
+      body.challengeId,
+      body.memberId,
+      submissionType,
+    ].join(':');
+
+    return this.prisma.$transaction(async (transaction) => {
+      await transaction.$executeRaw(
+        Prisma.sql`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`,
+      );
+
+      const existingSubmissionCount = await transaction.submission.count({
+        where: {
+          challengeId: body.challengeId,
+          memberId: body.memberId,
+          type: submissionType,
+          status: { not: SubmissionStatus.DELETED },
+        },
+      });
+
+      if (existingSubmissionCount >= submissionLimit) {
+        const message =
+          submissionLimit === 1
+            ? "This challenge allows only one submission, and you've already submitted. To replace it, delete your existing submission first."
+            : `This challenge allows only ${submissionLimit} submissions, and you've already reached that limit. To replace one, delete an existing submission first.`;
+
+        throw new BadRequestException({
+          message,
+          code: 'SUBMISSION_LIMIT_REACHED',
+          details: {
+            challengeId: body.challengeId,
+            memberId: body.memberId,
+            submissionType,
+            submissionLimit,
+            existingSubmissionCount,
+          },
+        });
+      }
+
+      return transaction.submission.create({ data });
+    });
+  }
+
   async createSubmission(
     authUser: JwtUser,
     body: SubmissionRequestDto,
@@ -3564,26 +3795,29 @@ export class SubmissionService {
         }
       }
 
-      const data = await this.prisma.submission.create({
-        data: {
-          ...body,
-          isFileSubmission,
-          // populate commonly expected fields on create
-          submittedDate: body.submittedDate
-            ? new Date(body.submittedDate)
-            : new Date(),
-          systemFileName,
-          fileType,
-          viewCount: 0,
-          status: SubmissionStatus.ACTIVE,
-          type: body.type as SubmissionType,
-          virusScan: false,
-          eventRaised: false,
-          confirmationEmail: {
-            create: {},
-          },
+      const submissionData: Prisma.submissionCreateArgs['data'] = {
+        ...body,
+        isFileSubmission,
+        // populate commonly expected fields on create
+        submittedDate: body.submittedDate
+          ? new Date(body.submittedDate)
+          : new Date(),
+        systemFileName,
+        fileType,
+        viewCount: 0,
+        status: SubmissionStatus.ACTIVE,
+        type: body.type as SubmissionType,
+        virusScan: false,
+        eventRaised: false,
+        confirmationEmail: {
+          create: {},
         },
-      });
+      };
+      const data = await this.createSubmissionWithLimit(
+        challengeDetails,
+        body,
+        submissionData,
+      );
       this.logger.log(`Submission created with ID: ${data.id}`);
       if (isFileSubmission) {
         await this.publishSubmissionScanEvent(data);
@@ -3641,6 +3875,9 @@ export class SubmissionService {
       await this.stripIsLatestForUnlimitedChallenges([data]);
       return this.buildResponse(data);
     } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       const errorResponse = this.prismaErrorService.handleError(
         error,
         `creating submission for challengeId: ${body.challengeId}, memberId: ${body.memberId}`,

--- a/src/shared/utils/submission-limit.util.spec.ts
+++ b/src/shared/utils/submission-limit.util.spec.ts
@@ -1,0 +1,195 @@
+import {
+  isExplicitUnlimitedSubmissionLimit,
+  isSubmissionRankEligible,
+  parseSubmissionLimitCount,
+  resolveReviewSubmissionRankLimit,
+} from './submission-limit.util';
+
+describe('submission-limit utilities', () => {
+  const countAliases = ['count', 'max', 'maximum', 'limitCount', 'value'];
+  const trueFlagValues = [true, 'true', 'yes', '1', 1];
+  const falseFlagValues = [false, 'false', 'no', '0', 0];
+  const resolveDesignLimit = (submissionLimit: unknown): number | null =>
+    resolveReviewSubmissionRankLimit({
+      track: 'Design',
+      legacy: {},
+      metadata: { submissionLimit },
+    });
+
+  describe('parseSubmissionLimitCount', () => {
+    it.each(countAliases)(
+      'parses the legacy finite count alias %s',
+      (countField) => {
+        const value = JSON.stringify({ [countField]: '3' });
+
+        expect(parseSubmissionLimitCount(value)).toBe(3);
+        expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(false);
+        expect(resolveDesignLimit(value)).toBe(3);
+      },
+    );
+
+    it.each(trueFlagValues)('parses the limited flag form %p', (limitFlag) => {
+      const value = JSON.stringify({ count: '2', limit: limitFlag });
+
+      expect(parseSubmissionLimitCount(value)).toBe(2);
+      expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(false);
+      expect(resolveDesignLimit(value)).toBe(2);
+    });
+
+    it.each(falseFlagValues)(
+      'parses the disabled unlimited flag form %p with a finite count',
+      (unlimitedFlag) => {
+        const value = JSON.stringify({
+          count: '2',
+          unlimited: unlimitedFlag,
+        });
+
+        expect(parseSubmissionLimitCount(value)).toBe(2);
+        expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(false);
+        expect(resolveDesignLimit(value)).toBe(2);
+      },
+    );
+
+    it.each([1, '2', JSON.stringify(3)])(
+      'parses the positive scalar value %p',
+      (value) => {
+        expect(parseSubmissionLimitCount(value)).toBe(Number(value));
+      },
+    );
+
+    it('parses canonical finite metadata', () => {
+      const value = JSON.stringify({
+        count: '3',
+        limit: 'true',
+        unlimited: 'false',
+      });
+
+      expect(parseSubmissionLimitCount(value)).toBe(3);
+      expect(resolveDesignLimit(value)).toBe(3);
+    });
+
+    it.each([
+      undefined,
+      null,
+      '',
+      '{invalid',
+      JSON.stringify({ count: '', limit: 'false', unlimited: 'true' }),
+      JSON.stringify({ count: '0', limit: 'true', unlimited: 'false' }),
+    ])('treats %p as uncapped', (value) => {
+      expect(parseSubmissionLimitCount(value)).toBeNull();
+    });
+  });
+
+  describe('isExplicitUnlimitedSubmissionLimit', () => {
+    it.each(['unlimited', 'false', '0', 'no', 'none', false, 0])(
+      'recognizes the legacy explicit-unlimited scalar %p',
+      (value) => {
+        expect(parseSubmissionLimitCount(value)).toBeNull();
+        expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(true);
+        expect(resolveDesignLimit(value)).toBeNull();
+      },
+    );
+
+    it.each(trueFlagValues)(
+      'recognizes the unlimited flag form %p',
+      (unlimitedFlag) => {
+        const value = JSON.stringify({
+          count: '2',
+          unlimited: unlimitedFlag,
+        });
+
+        expect(parseSubmissionLimitCount(value)).toBeNull();
+        expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(true);
+        expect(resolveDesignLimit(value)).toBeNull();
+      },
+    );
+
+    it.each(falseFlagValues)(
+      'recognizes the disabled limit flag form %p',
+      (limitFlag) => {
+        const value = JSON.stringify({ count: '2', limit: limitFlag });
+
+        expect(parseSubmissionLimitCount(value)).toBeNull();
+        expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(true);
+        expect(resolveDesignLimit(value)).toBeNull();
+      },
+    );
+
+    it('gives explicit unlimited flags precedence over a stale count', () => {
+      const value = JSON.stringify({
+        maximum: '4',
+        limit: 'false',
+        unlimited: 'true',
+      });
+
+      expect(parseSubmissionLimitCount(value)).toBeNull();
+      expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(true);
+      expect(resolveDesignLimit(value)).toBeNull();
+    });
+
+    it.each([
+      ['both true', { count: 2, limit: 'yes', unlimited: 1 }],
+      ['both false', { count: 2, limit: 'no', unlimited: 0 }],
+    ])('treats contradictory %s flags as malformed', (_description, value) => {
+      const serializedValue = JSON.stringify(value);
+
+      expect(parseSubmissionLimitCount(serializedValue)).toBeNull();
+      expect(isExplicitUnlimitedSubmissionLimit(serializedValue)).toBe(false);
+      expect(resolveDesignLimit(serializedValue)).toBe(1);
+    });
+
+    it.each([
+      true,
+      '{invalid',
+      JSON.stringify({ limit: 'yes' }),
+      JSON.stringify({ unlimited: 'false' }),
+    ])('treats malformed value %p as latest-only for review', (value) => {
+      expect(parseSubmissionLimitCount(value)).toBeNull();
+      expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(false);
+      expect(resolveDesignLimit(value)).toBe(1);
+    });
+  });
+
+  describe('resolveReviewSubmissionRankLimit', () => {
+    it('defaults missing Design metadata to uncapped', () => {
+      expect(
+        resolveReviewSubmissionRankLimit({
+          track: 'Design',
+          legacy: {},
+        }),
+      ).toBeNull();
+    });
+
+    it('keeps non-Design challenges latest-only regardless of metadata', () => {
+      expect(
+        resolveReviewSubmissionRankLimit({
+          track: 'Development',
+          legacy: {},
+          metadata: {
+            submissionLimit: JSON.stringify({
+              maximum: '3',
+              limit: 'yes',
+              unlimited: 'no',
+            }),
+          },
+        }),
+      ).toBe(1);
+    });
+
+    it('keeps malformed and contradictory Design metadata latest-only', () => {
+      for (const value of [
+        '{invalid',
+        JSON.stringify({ count: '2', limit: true, unlimited: true }),
+      ]) {
+        expect(isExplicitUnlimitedSubmissionLimit(value)).toBe(false);
+        expect(resolveDesignLimit(value)).toBe(1);
+      }
+    });
+  });
+
+  it('checks finite ranks while allowing all uncapped ranks', () => {
+    expect(isSubmissionRankEligible(2, 2)).toBe(true);
+    expect(isSubmissionRankEligible(3, 2)).toBe(false);
+    expect(isSubmissionRankEligible(null, null)).toBe(true);
+  });
+});

--- a/src/shared/utils/submission-limit.util.ts
+++ b/src/shared/utils/submission-limit.util.ts
@@ -1,0 +1,261 @@
+import type { ChallengeData } from 'src/shared/modules/global/challenge.service';
+
+type SubmissionLimitChallenge = Pick<ChallengeData, 'track' | 'legacy'> & {
+  metadata?: Record<string, unknown> | undefined;
+};
+
+type SubmissionLimitPolicy =
+  | { mode: 'finite'; count: number }
+  | { mode: 'unlimited' }
+  | { mode: 'malformed' };
+
+const SUBMISSION_LIMIT_COUNT_FIELDS = [
+  'count',
+  'max',
+  'maximum',
+  'limitCount',
+  'value',
+] as const;
+
+/**
+ * Converts a submission-limit count to a positive integer.
+ *
+ * @param value - Raw scalar count from current or legacy challenge metadata.
+ * @returns The positive integer count, or null when the value is not a limit.
+ * @throws Never.
+ */
+function toPositiveInteger(value: unknown): number | null {
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return null;
+  }
+
+  const numericValue = Number(value);
+  return Number.isSafeInteger(numericValue) && numericValue > 0
+    ? numericValue
+    : null;
+}
+
+/**
+ * Parses a loosely typed submission-limit metadata flag.
+ *
+ * @param value - Boolean-like value from submission-limit metadata.
+ * @returns The parsed boolean, or null when the flag is not recognizable.
+ * @throws Never.
+ */
+function parseMetadataBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalizedValue = value.trim().toLowerCase();
+    if (['true', 'yes', '1'].includes(normalizedValue)) {
+      return true;
+    }
+    if (['false', 'no', '0'].includes(normalizedValue)) {
+      return false;
+    }
+    return null;
+  }
+
+  if (value === 1) {
+    return true;
+  }
+  if (value === 0) {
+    return false;
+  }
+
+  return null;
+}
+
+/**
+ * Resolves raw current or legacy metadata into one submission-limit policy.
+ *
+ * Current and legacy count aliases share the same precedence as Autopilot.
+ * Equal recognized `limit` and `unlimited` flags are contradictory. Otherwise
+ * `unlimited=true` or `limit=false` takes precedence over a stale count.
+ *
+ * @param value - Raw `submissionLimit` challenge metadata value.
+ * @returns A finite count, explicit unlimited mode, or malformed mode.
+ * @throws Never; malformed serialized metadata is returned as malformed.
+ */
+function resolveSubmissionLimitPolicy(value: unknown): SubmissionLimitPolicy {
+  let parsedValue = value;
+  if (typeof value === 'string') {
+    const normalizedValue = value.trim();
+    if (!normalizedValue) {
+      return { mode: 'malformed' };
+    }
+
+    try {
+      parsedValue = JSON.parse(normalizedValue);
+    } catch {
+      parsedValue = normalizedValue;
+    }
+  }
+
+  const primitiveLimit = toPositiveInteger(parsedValue);
+  if (primitiveLimit !== null) {
+    return { mode: 'finite', count: primitiveLimit };
+  }
+
+  if (typeof parsedValue === 'number' && parsedValue === 0) {
+    return { mode: 'unlimited' };
+  }
+
+  if (typeof parsedValue === 'boolean') {
+    return parsedValue ? { mode: 'malformed' } : { mode: 'unlimited' };
+  }
+
+  if (typeof parsedValue === 'string') {
+    return ['unlimited', 'false', '0', 'no', 'none'].includes(
+      parsedValue.trim().toLowerCase(),
+    )
+      ? { mode: 'unlimited' }
+      : { mode: 'malformed' };
+  }
+
+  if (
+    !parsedValue ||
+    typeof parsedValue !== 'object' ||
+    Array.isArray(parsedValue)
+  ) {
+    return { mode: 'malformed' };
+  }
+
+  const metadata = parsedValue as Record<string, unknown>;
+  const unlimited = parseMetadataBoolean(metadata.unlimited);
+  const limit = parseMetadataBoolean(metadata.limit);
+  const countValue = SUBMISSION_LIMIT_COUNT_FIELDS.map(
+    (fieldName) => metadata[fieldName],
+  ).find(
+    (candidate) =>
+      candidate !== undefined && candidate !== null && candidate !== '',
+  );
+  const count = toPositiveInteger(countValue);
+  const flagsConflict =
+    unlimited !== null && limit !== null && unlimited === limit;
+
+  if (flagsConflict) {
+    return { mode: 'malformed' };
+  }
+
+  if (unlimited === true || limit === false) {
+    return { mode: 'unlimited' };
+  }
+
+  return count === null ? { mode: 'malformed' } : { mode: 'finite', count };
+}
+
+/**
+ * Reads the finite count from current or legacy submission-limit metadata.
+ *
+ * Current metadata uses `count`, `limit`, and `unlimited`. Legacy aliases
+ * `max`, `maximum`, `limitCount`, and `value`, loose boolean flags, positive
+ * scalar values, and flag-less count objects remain supported. Missing,
+ * malformed, contradictory, invalid, or unlimited values are treated as
+ * uncapped by submission creation.
+ *
+ * @param value - Raw `submissionLimit` challenge metadata value.
+ * @returns A positive finite limit, or null when submissions are uncapped.
+ * @throws Never; malformed serialized metadata is handled as uncapped.
+ */
+export function parseSubmissionLimitCount(value: unknown): number | null {
+  const policy = resolveSubmissionLimitPolicy(value);
+  return policy.mode === 'finite' ? policy.count : null;
+}
+
+/**
+ * Checks whether metadata explicitly and consistently enables unlimited submissions.
+ *
+ * @param value - Raw `submissionLimit` challenge metadata value.
+ * @returns True only for a recognizable unlimited value without a conflicting limit flag.
+ * @throws Never; malformed serialized metadata is not treated as unlimited.
+ */
+export function isExplicitUnlimitedSubmissionLimit(value: unknown): boolean {
+  return resolveSubmissionLimitPolicy(value).mode === 'unlimited';
+}
+
+/**
+ * Determines whether challenge data identifies the Design track.
+ *
+ * @param challenge - Challenge data containing current and optional legacy track names.
+ * @returns True when either track name is Design.
+ * @throws Never.
+ */
+export function isDesignTrackChallenge(
+  challenge: SubmissionLimitChallenge | null | undefined,
+): boolean {
+  return [challenge?.track, challenge?.legacy?.track].some(
+    (track) =>
+      String(track ?? '')
+        .trim()
+        .toLowerCase() === 'design',
+  );
+}
+
+/**
+ * Resolves the per-member rank limit used when selecting submissions for review.
+ *
+ * Design challenges use their configured finite count, allow all submissions
+ * when metadata is missing or explicitly unlimited, and fail closed to the
+ * latest submission for malformed metadata. Other tracks retain their
+ * established latest-submission-only behavior. Missing challenge data also
+ * fails closed to the latest submission.
+ *
+ * @param challenge - Challenge and submission-limit metadata.
+ * @returns A positive maximum rank, or null when all Design submissions qualify.
+ * @throws Never.
+ */
+export function resolveReviewSubmissionRankLimit(
+  challenge: SubmissionLimitChallenge | null | undefined,
+): number | null {
+  if (!challenge || !isDesignTrackChallenge(challenge)) {
+    return 1;
+  }
+
+  if (
+    !challenge.metadata ||
+    !Object.prototype.hasOwnProperty.call(
+      challenge.metadata,
+      'submissionLimit',
+    ) ||
+    challenge.metadata.submissionLimit === null ||
+    challenge.metadata.submissionLimit === undefined
+  ) {
+    return null;
+  }
+
+  const policy = resolveSubmissionLimitPolicy(
+    challenge.metadata.submissionLimit,
+  );
+  if (policy.mode === 'finite') {
+    return policy.count;
+  }
+
+  return policy.mode === 'unlimited' ? null : 1;
+}
+
+/**
+ * Checks whether a ranked submission falls within a configured review limit.
+ *
+ * @param rank - One-based member submission rank, newest first.
+ * @param maximumRank - Positive maximum rank, or null for uncapped Design submissions.
+ * @returns True when the submission is eligible for screening or review.
+ * @throws Never.
+ */
+export function isSubmissionRankEligible(
+  rank: number | null | undefined,
+  maximumRank: number | null,
+): boolean {
+  if (maximumRank === null) {
+    return true;
+  }
+
+  return (
+    typeof rank === 'number' &&
+    Number.isInteger(rank) &&
+    rank > 0 &&
+    rank <= maximumRank
+  );
+}


### PR DESCRIPTION
## What was broken

The submission API accepted concurrent requests beyond a finite Design limit, finite counts above one were reduced to latest-only review behavior, and submissions could advance to Review without passing the preceding Screening phase.

## Root cause

Submission limits were enforced only by client-side read-before-write checks. Review eligibility used a boolean latest flag rather than the configured count, and automatic and direct review paths lacked positive screening-pass gates.

## What was changed

Added a transaction-scoped advisory lock around same-member, same-type count and create operations for finite Design limits. Added a shared current-and-legacy metadata policy, exact-type submission ranks, latest-X screening and review eligibility, standard Screening-to-Review and Checkpoint Screening-to-Checkpoint Review pass gates, and a direct standard Review pass check.

## Any added/updated tests

Added metadata-policy parity tests and expanded submission and review service coverage for atomic limits, concurrent final-slot requests, checkpoint and contest isolation, legacy metadata aliases, latest-X ranks, Development latest-only behavior, and passing, failed, or missing screening outcomes.

Validation:

- Ticket-focused tests passed: 168 tests.
- Lint passed.
- Build passed.
- The full branch suite passed 382 tests and reported the same 8 unrelated failures reproduced on an unchanged origin/develop worktree. No PM-5758 test failed.
